### PR TITLE
Feat behavior velocity occlusion spot more efficient

### DIFF
--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -6,7 +6,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-secret:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
+    secrets:
+      secret: ${{ secrets.APP_ID }}
+
   sync-files:
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.set == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate token

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,13 +35,14 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.6.0
+    rev: v0.7.0
     hooks:
+      - id: flake8-ros
       - id: prettier-xacro
       - id: prettier-launch-xml
       - id: prettier-package-xml
-      - id: sort-package-xml
       - id: ros-include-guard
+      - id: sort-package-xml
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.8.0.4
@@ -65,24 +66,8 @@ repos:
       - id: black
         args: [--line-length=100]
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          [
-            flake8-blind-except,
-            flake8-builtins,
-            flake8-class-newline,
-            flake8-comprehensions,
-            flake8-deprecated,
-            flake8-docstrings,
-            flake8-import-order,
-            flake8-quotes,
-          ]
-
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.1
+    rev: v14.0.1
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]

--- a/common/autoware_ad_api_msgs/CMakeLists.txt
+++ b/common/autoware_ad_api_msgs/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+project(autoware_ad_api_msgs)
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  srv/InterfaceVersion.srv
+  DEPENDENCIES
+    builtin_interfaces
+    std_msgs
+    geometry_msgs
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package()

--- a/common/autoware_ad_api_msgs/README.md
+++ b/common/autoware_ad_api_msgs/README.md
@@ -1,0 +1,17 @@
+# autoware_ad_api_msgs
+
+## InterfaceVersion
+
+This API provides the interface version of the set of AD APIs.
+It follows [Semantic Versioning][semver] in order to provide an intuitive understanding of the changes between versions.
+
+### Use cases
+
+Considering the product life cycle, there will be multiple vehicles that use different versions of the AD API due to changes in requirements or some improvements.
+For example, a vehicle uses `v1` for stability and another vehicle uses `v2` for more functionality.
+
+In that situation, the AD API users such as developers of a Web service have to switch the application behavior based on the version that each vehicle uses.
+
+<!-- link -->
+
+[semver]: https://semver.org/

--- a/common/autoware_ad_api_msgs/package.xml
+++ b/common/autoware_ad_api_msgs/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_ad_api_msgs</name>
+  <version>0.0.0</version>
+  <description>The autoware_ad_api_msgs package</description>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_ad_api_msgs/srv/InterfaceVersion.srv
+++ b/common/autoware_ad_api_msgs/srv/InterfaceVersion.srv
@@ -1,0 +1,4 @@
+---
+uint16 major
+uint16 minor
+uint16 patch

--- a/common/autoware_auto_common/CMakeLists.txt
+++ b/common/autoware_auto_common/CMakeLists.txt
@@ -48,20 +48,25 @@ if(BUILD_TESTING)
   # Unit tests
   set(TEST_COMMON test_common_gtest)
   ament_add_gtest(${TEST_COMMON}
-          test/gtest_main.cpp
-          test/test_bool_comparisons.cpp
-          test/test_byte_reader.cpp
-          test/test_float_comparisons.cpp
-          test/test_mahalanobis_distance.cpp
-          test/test_message_field_adapters.cpp
-          test/test_template_utils.cpp
-          test/test_angle_utils.cpp
-          test/test_type_name.cpp
-          test/test_type_traits.cpp)
+    test/gtest_main.cpp
+    test/test_bool_comparisons.cpp
+    test/test_byte_reader.cpp
+    test/test_float_comparisons.cpp
+    test/test_mahalanobis_distance.cpp
+    test/test_message_field_adapters.cpp
+    test/test_template_utils.cpp
+    test/test_angle_utils.cpp
+    test/test_type_name.cpp
+    test/test_type_traits.cpp
+  )
   autoware_set_compile_options(${TEST_COMMON})
   target_compile_options(${TEST_COMMON} PRIVATE -Wno-sign-conversion)
   target_include_directories(${TEST_COMMON} PRIVATE include)
-  ament_target_dependencies(${TEST_COMMON} builtin_interfaces Eigen3)
+  ament_target_dependencies(${TEST_COMMON}
+    builtin_interfaces
+    Eigen3
+    geometry_msgs
+  )
 endif()
 
 # Ament Exporting

--- a/common/autoware_auto_common/package.xml
+++ b/common/autoware_auto_common/package.xml
@@ -10,12 +10,13 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_auto_cmake</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>eigen</build_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>eigen</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>geometry_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/common/autoware_auto_geometry/CMakeLists.txt
+++ b/common/autoware_auto_geometry/CMakeLists.txt
@@ -31,6 +31,13 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/bounding_box.cpp)
 autoware_set_compile_options(${PROJECT_NAME})
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 if(BUILD_TESTING)
   # run linters
   find_package(ament_lint_auto REQUIRED)

--- a/common/autoware_auto_tf2/CMakeLists.txt
+++ b/common/autoware_auto_tf2/CMakeLists.txt
@@ -30,6 +30,12 @@ if(BUILD_TESTING)
   # Unit test
   ament_add_gtest(test_tf2_autoware_auto_msgs test/test_tf2_autoware_auto_msgs.cpp)
   autoware_set_compile_options(test_tf2_autoware_auto_msgs)
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(test_tf2_autoware_auto_msgs PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
   target_include_directories(test_tf2_autoware_auto_msgs PRIVATE "include")
   ament_target_dependencies(test_tf2_autoware_auto_msgs
     "autoware_auto_common"
@@ -39,8 +45,9 @@ if(BUILD_TESTING)
     "geometry_msgs"
     "orocos_kdl"
     "tf2"
+    "tf2_geometry_msgs"
     "tf2_ros"
-)
+  )
 endif()
 
 ament_auto_package()

--- a/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -29,7 +29,12 @@
 
 #include <tf2/convert.h>
 #include <tf2/time.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <string>
 

--- a/common/autoware_auto_tf2/package.xml
+++ b/common/autoware_auto_tf2/package.xml
@@ -17,6 +17,7 @@
   <depend>geometry_msgs</depend>
   <depend>orocos_kdl</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs.cpp
+++ b/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs.cpp
@@ -18,7 +18,6 @@
 #include <rclcpp/clock.hpp>
 
 #include <gtest/gtest.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/common/component_interface_utils/CMakeLists.txt
+++ b/common/component_interface_utils/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.8)
+project(component_interface_utils)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package()

--- a/common/component_interface_utils/README.md
+++ b/common/component_interface_utils/README.md
@@ -1,0 +1,26 @@
+# component_interface_utils
+
+## Features
+
+This is a utility package that provides the following features:
+
+- Logging for service and client
+
+## Usage
+
+1. This package requires interface information in this format.
+
+   ```cpp
+   struct SampleService
+   {
+     using Service = sample_msgs::srv::ServiceType;
+     static constexpr char name[] = "/sample/service";
+   };
+   ```
+
+2. Create a wrapper using the above definition as follows.
+
+   ```cpp
+   component_interface_utils::Service<SampleService>::SharedPtr srv_;
+   srv_ = component_interface_utils::create_service<SampleService>(node, ...);
+   ```

--- a/common/component_interface_utils/include/component_interface_utils/rclcpp.hpp
+++ b/common/component_interface_utils/include/component_interface_utils/rclcpp.hpp
@@ -1,0 +1,21 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_
+#define COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_
+
+#include <component_interface_utils/rclcpp/create_interface.hpp>
+#include <component_interface_utils/rclcpp/service_server.hpp>
+
+#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP_HPP_

--- a/common/component_interface_utils/include/component_interface_utils/rclcpp/create_interface.hpp
+++ b/common/component_interface_utils/include/component_interface_utils/rclcpp/create_interface.hpp
@@ -1,0 +1,61 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_
+#define COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_
+
+#include <component_interface_utils/rclcpp/service_server.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <utility>
+
+namespace component_interface_utils
+{
+
+/// Create a service wrapper for logging. This is a private implementation.
+template <class SpecT, class NodeT, class CallbackT>
+typename Service<SpecT>::SharedPtr create_service_impl(
+  NodeT * node, CallbackT && callback, rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  // Use a node pointer because shared_from_this cannot be used in constructor.
+  // This function is a wrapper for the following.
+  // https://github.com/ros2/rclcpp/blob/48068130edbb43cdd61076dc1851672ff1a80408/rclcpp/include/rclcpp/node.hpp#L267-L281
+  auto wrapped = Service<SpecT>::wrap(callback, node->get_logger());
+  auto service = node->template create_service<typename SpecT::Service>(
+    SpecT::name, wrapped, rmw_qos_profile_services_default, group);
+  return Service<SpecT>::make_shared(service);
+}
+
+/// Create a service wrapper for logging. This is for lambda or bound function.
+template <class SpecT, class NodeT, class CallbackT>
+typename Service<SpecT>::SharedPtr create_service(
+  NodeT * node, CallbackT && callback, rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  return create_service_impl<SpecT>(node, std::forward<CallbackT>(callback), group);
+}
+
+/// Create a service wrapper for logging. This is for member function of node.
+template <class SpecT, class NodeT>
+typename Service<SpecT>::SharedPtr create_service(
+  NodeT * node, typename Service<SpecT>::template CallbackType<NodeT> callback,
+  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  return create_service_impl<SpecT>(node, std::bind(callback, node, _1, _2), group);
+}
+
+}  // namespace component_interface_utils
+
+#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__CREATE_INTERFACE_HPP_

--- a/common/component_interface_utils/include/component_interface_utils/rclcpp/service_server.hpp
+++ b/common/component_interface_utils/include/component_interface_utils/rclcpp/service_server.hpp
@@ -1,0 +1,62 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_
+#define COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace component_interface_utils
+{
+
+/// The wrapper class of rclcpp::Service for logging.
+template <class SpecT>
+class Service
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(Service)
+
+  template <class NodeT>
+  using CallbackType = void (NodeT::*)(
+    typename SpecT::Service::Request::SharedPtr, typename SpecT::Service::Response::SharedPtr);
+
+  /// Constructor.
+  explicit Service(typename rclcpp::Service<typename SpecT::Service>::SharedPtr service)
+  {
+    service_ = service;  // to keep the reference count
+  }
+
+  /// Create a service callback with logging added.
+  template <class CallbackT>
+  static auto wrap(CallbackT && callback, const rclcpp::Logger & logger)
+  {
+    auto wrapped = [logger, callback](
+                     typename SpecT::Service::Request::SharedPtr request,
+                     typename SpecT::Service::Response::SharedPtr response) {
+      using rosidl_generator_traits::to_yaml;
+      RCLCPP_INFO_STREAM(logger, "service call: " << SpecT::name << "\n" << to_yaml(*request));
+      callback(request, response);
+      RCLCPP_INFO_STREAM(logger, "service exit: " << SpecT::name << "\n" << to_yaml(*response));
+    };
+    return wrapped;
+  }
+
+private:
+  RCLCPP_DISABLE_COPY(Service)
+  typename rclcpp::Service<typename SpecT::Service>::SharedPtr service_;
+};
+
+}  // namespace component_interface_utils
+
+#endif  // COMPONENT_INTERFACE_UTILS__RCLCPP__SERVICE_SERVER_HPP_

--- a/common/component_interface_utils/include/component_interface_utils/rclcpp/service_server.hpp
+++ b/common/component_interface_utils/include/component_interface_utils/rclcpp/service_server.hpp
@@ -44,7 +44,9 @@ public:
     auto wrapped = [logger, callback](
                      typename SpecT::Service::Request::SharedPtr request,
                      typename SpecT::Service::Response::SharedPtr response) {
+#ifdef USE_DEPRECATED_TO_YAML
       using rosidl_generator_traits::to_yaml;
+#endif
       RCLCPP_INFO_STREAM(logger, "service call: " << SpecT::name << "\n" << to_yaml(*request));
       callback(request, response);
       RCLCPP_INFO_STREAM(logger, "service exit: " << SpecT::name << "\n" << to_yaml(*response));

--- a/common/component_interface_utils/package.xml
+++ b/common/component_interface_utils/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>component_interface_utils</name>
+  <version>0.0.0</version>
+  <description>The component_interface_utils package</description>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>autoware_ad_api_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/had_map_utils/CMakeLists.txt
+++ b/common/had_map_utils/CMakeLists.txt
@@ -25,9 +25,13 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/had_map_query.cpp
   src/had_map_visualization.cpp)
 
-# Disable warnings due to external dependencies (Eigen)
+# Disable warnings due to external dependencies
+get_target_property(lanelet2_core_INCLUDE_DIR
+  lanelet2_core::lanelet2_core INTERFACE_INCLUDE_DIRECTORIES
+)
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   ${EIGEN3_INCLUDE_DIR}
+  ${lanelet2_core_INCLUDE_DIR}
   ${rclcpp_INCLUDE_DIRS}
 )
 

--- a/common/motion_common/CMakeLists.txt
+++ b/common/motion_common/CMakeLists.txt
@@ -15,6 +15,13 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 autoware_set_compile_options(${PROJECT_NAME})
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 ### Test
 if(BUILD_TESTING)
   # Linters

--- a/common/motion_common/include/motion_common/motion_common.hpp
+++ b/common/motion_common/include/motion_common/motion_common.hpp
@@ -26,7 +26,12 @@
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <cmath>

--- a/common/motion_common/src/motion_common/motion_common.cpp
+++ b/common/motion_common/src/motion_common/motion_common.cpp
@@ -17,8 +17,6 @@
 #include "helper_functions/angle_utils.hpp"
 #include "tf2/utils.h"
 
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
-
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/common/motion_testing/CMakeLists.txt
+++ b/common/motion_testing/CMakeLists.txt
@@ -10,6 +10,13 @@ ament_auto_find_build_dependencies()
 ament_auto_add_library(${PROJECT_NAME} SHARED src/motion_testing/motion_testing.cpp)
 autoware_set_compile_options(${PROJECT_NAME})
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 ### Test
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/common/motion_testing/src/motion_testing/motion_testing.cpp
+++ b/common/motion_testing/src/motion_testing/motion_testing.cpp
@@ -18,7 +18,12 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <limits>
 

--- a/common/osqp_interface/CMakeLists.txt
+++ b/common/osqp_interface/CMakeLists.txt
@@ -19,13 +19,16 @@ project(osqp_interface)
 # require that dependencies from package.xml be available
 find_package(ament_cmake_auto REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(osqp REQUIRED)
-get_target_property(OSQP_INCLUDE_DIR osqp::osqp INTERFACE_INCLUDE_DIRECTORIES)
 
 ament_auto_find_build_dependencies(REQUIRED
   ${${PROJECT_NAME}_BUILD_DEPENDS}
   ${${PROJECT_NAME}_BUILDTOOL_DEPENDS}
 )
+
+# after find_package(osqp_vendor) in ament_auto_find_build_dependencies
+find_package(osqp REQUIRED)
+get_target_property(OSQP_INCLUDE_SUB_DIR osqp::osqp INTERFACE_INCLUDE_DIRECTORIES)
+get_filename_component(OSQP_INCLUDE_DIR ${OSQP_INCLUDE_SUB_DIR} PATH)
 
 set(OSQP_INTERFACE_LIB_SRC
   src/csc_matrix_conv.cpp
@@ -46,7 +49,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 autoware_set_compile_options(${PROJECT_NAME})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-error=old-style-cast -Wno-error=useless-cast)
 
-target_include_directories(osqp_interface PUBLIC "${OSQP_INCLUDE_DIR}")
+target_include_directories(osqp_interface
+  SYSTEM PUBLIC
+    "${OSQP_INCLUDE_DIR}"
+)
+
 ament_target_dependencies(osqp_interface
   Eigen3
   osqp_vendor

--- a/common/tier4_perception_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_perception_rviz_plugin/CMakeLists.txt
@@ -32,6 +32,13 @@ ament_auto_add_library(tier4_perception_rviz_plugin SHARED
 target_link_libraries(tier4_perception_rviz_plugin
   ${QT_LIBRARIES})
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(tier4_perception_rviz_plugin PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 # Export the plugin to be imported by rviz2
 pluginlib_export_plugin_description_file(rviz_common plugins/plugin_description.xml)
 

--- a/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
+++ b/common/tier4_perception_rviz_plugin/src/tools/interactive_object.hpp
@@ -66,7 +66,12 @@
 
 #include <boost/optional.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/transform_listener.h>
 
 #include <algorithm>

--- a/common/tier4_planning_rviz_plugin/src/tools/jsk_overlay_utils.hpp
+++ b/common/tier4_planning_rviz_plugin/src/tools/jsk_overlay_utils.hpp
@@ -60,7 +60,9 @@
 #endif
 
 #include <QColor>
+#include <QCursor>
 #include <QImage>
+#include <QVariant>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_rendering/render_system.hpp>
 

--- a/control/control_performance_analysis/CMakeLists.txt
+++ b/control/control_performance_analysis/CMakeLists.txt
@@ -35,8 +35,14 @@ ament_auto_add_library(control_performance_analysis_node SHARED
   src/control_performance_analysis_node.cpp
 )
 
-rosidl_target_interfaces(control_performance_analysis_node
-  control_performance_analysis_msgs "rosidl_typesupport_cpp")
+if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
+  rosidl_target_interfaces(control_performance_analysis_node
+    control_performance_analysis_msgs "rosidl_typesupport_cpp")
+else()
+  rosidl_get_typesupport_target(
+    cpp_typesupport_target control_performance_analysis_msgs "rosidl_typesupport_cpp")
+  target_link_libraries(control_performance_analysis_node "${cpp_typesupport_target}")
+endif()
 
 target_link_libraries(control_performance_analysis_node
   control_performance_analysis_core

--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -17,6 +17,7 @@
   <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>

--- a/control/obstacle_collision_checker/CMakeLists.txt
+++ b/control/obstacle_collision_checker/CMakeLists.txt
@@ -44,6 +44,10 @@ rclcpp_components_register_node(obstacle_collision_checker
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_add_ros_isolated_gtest(test_obstacle_collision_checker
+    test/test_obstacle_collision_checker.cpp
+  )
+  target_link_libraries(test_obstacle_collision_checker obstacle_collision_checker)
 endif()
 
 ament_auto_package(

--- a/control/obstacle_collision_checker/package.xml
+++ b/control/obstacle_collision_checker/package.xml
@@ -26,6 +26,7 @@
   <depend>tier4_autoware_utils</depend>
   <depend>vehicle_info_util</depend>
 
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/control/obstacle_collision_checker/src/obstacle_collision_checker_node/obstacle_collision_checker.cpp
+++ b/control/obstacle_collision_checker/src/obstacle_collision_checker_node/obstacle_collision_checker.cpp
@@ -27,7 +27,12 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 #include <iostream>
 #include <vector>

--- a/control/obstacle_collision_checker/src/obstacle_collision_checker_node/obstacle_collision_checker.cpp
+++ b/control/obstacle_collision_checker/src/obstacle_collision_checker_node/obstacle_collision_checker.cpp
@@ -59,12 +59,13 @@ pcl::PointCloud<pcl::PointXYZ> filterPointCloudByTrajectory(
   const autoware_auto_planning_msgs::msg::Trajectory & trajectory, const double radius)
 {
   pcl::PointCloud<pcl::PointXYZ> filtered_pointcloud;
-  for (const auto & trajectory_point : trajectory.points) {
-    for (const auto & point : pointcloud.points) {
+  for (const auto & point : pointcloud.points) {
+    for (const auto & trajectory_point : trajectory.points) {
       const double dx = trajectory_point.pose.position.x - point.x;
       const double dy = trajectory_point.pose.position.y - point.y;
       if (std::hypot(dx, dy) < radius) {
         filtered_pointcloud.points.push_back(point);
+        break;
       }
     }
   }

--- a/control/obstacle_collision_checker/test/test_obstacle_collision_checker.cpp
+++ b/control/obstacle_collision_checker/test/test_obstacle_collision_checker.cpp
@@ -1,0 +1,46 @@
+// Copyright 2022 Tier IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/obstacle_collision_checker_node/obstacle_collision_checker.cpp"  // NOLINT
+#include "gtest/gtest.h"
+
+TEST(test_obstacle_collision_checker, filterPointCloudByTrajectory)
+{
+  pcl::PointCloud<pcl::PointXYZ> pcl;
+  autoware_auto_planning_msgs::msg::Trajectory trajectory;
+  pcl::PointXYZ pcl_point;
+  autoware_auto_planning_msgs::msg::TrajectoryPoint traj_point;
+  pcl_point.y = 0.0;
+  traj_point.pose.position.y = 0.99;
+  for (double x = 0.0; x < 10.0; x += 1.0) {
+    pcl_point.x = x;
+    traj_point.pose.position.x = x;
+    trajectory.points.push_back(traj_point);
+    pcl.push_back(pcl_point);
+  }
+  // radius < 1: all points are filtered
+  for (auto radius = 0.0; radius <= 0.99; radius += 0.1) {
+    const auto filtered_pcl = filterPointCloudByTrajectory(pcl, trajectory, radius);
+    EXPECT_EQ(filtered_pcl.size(), 0ul);
+  }
+  // radius >= 1.0: all points are kept
+  for (auto radius = 1.0; radius < 10.0; radius += 0.1) {
+    const auto filtered_pcl = filterPointCloudByTrajectory(pcl, trajectory, radius);
+    ASSERT_EQ(pcl.size(), filtered_pcl.size());
+    for (size_t i = 0; i < pcl.size(); ++i) {
+      EXPECT_EQ(pcl[i].x, filtered_pcl[i].x);
+      EXPECT_EQ(pcl[i].y, filtered_pcl[i].y);
+    }
+  }
+}

--- a/control/pure_pursuit/CMakeLists.txt
+++ b/control/pure_pursuit/CMakeLists.txt
@@ -27,6 +27,13 @@ ament_auto_add_library(pure_pursuit_core SHARED
   src/pure_pursuit_core/interpolate.cpp
 )
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(pure_pursuit_core PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 # pure_pursuit
 ament_auto_add_library(pure_pursuit_node SHARED
   src/pure_pursuit/pure_pursuit_node.cpp
@@ -39,7 +46,7 @@ target_link_libraries(pure_pursuit_node
 
 # workaround to allow deprecated header to build on both galactic and rolling
 if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
-  target_compile_definitions(pure_pursuit_node PUBLIC
+  target_compile_definitions(pure_pursuit_node PRIVATE
     USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
   )
 endif()

--- a/control/pure_pursuit/include/pure_pursuit/util/planning_utils.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/util/planning_utils.hpp
@@ -29,7 +29,15 @@
 
 #include <tf2/transform_datatypes.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <memory>
 #include <utility>

--- a/control/pure_pursuit/include/pure_pursuit/util/tf_utils.hpp
+++ b/control/pure_pursuit/include/pure_pursuit/util/tf_utils.hpp
@@ -19,7 +19,12 @@
 
 #include <boost/optional.hpp>  // To be replaced by std::optional in C++17
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/transform_listener.h>
 
 #include <string>

--- a/control/pure_pursuit/package.xml
+++ b/control/pure_pursuit/package.xml
@@ -18,6 +18,7 @@
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
   <depend>vehicle_info_util</depend>

--- a/control/trajectory_follower/CMakeLists.txt
+++ b/control/trajectory_follower/CMakeLists.txt
@@ -65,7 +65,7 @@ target_compile_options(${LATERAL_CONTROLLER_LIB} PRIVATE -Wno-error=old-style-ca
 
 # workaround to allow deprecated header to build on both galactic and rolling
 if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
-  target_compile_definitions(${LATERAL_CONTROLLER_LIB} PUBLIC
+  target_compile_definitions(${LATERAL_CONTROLLER_LIB} PRIVATE
     USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
   )
 endif()
@@ -95,7 +95,7 @@ target_compile_options(${LONGITUDINAL_CONTROLLER_LIB} PRIVATE -Wno-error=old-sty
 
 # workaround to allow deprecated header to build on both galactic and rolling
 if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
-  target_compile_definitions(${LONGITUDINAL_CONTROLLER_LIB} PUBLIC
+  target_compile_definitions(${LONGITUDINAL_CONTROLLER_LIB} PRIVATE
     USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
   )
 endif()
@@ -118,6 +118,13 @@ if(BUILD_TESTING)
   autoware_set_compile_options(${TEST_LATERAL_CONTROLLER_EXE})
   target_link_libraries(${TEST_LATERAL_CONTROLLER_EXE} ${LATERAL_CONTROLLER_LIB})
 
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(${TEST_LATERAL_CONTROLLER_EXE} PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
+
   set(TEST_LON_SOURCES
     test/test_debug_values.cpp
     test/test_pid.cpp
@@ -128,6 +135,13 @@ if(BUILD_TESTING)
   ament_add_gtest(${TEST_LONGITUDINAL_CONTROLLER_EXE} ${TEST_LON_SOURCES})
   autoware_set_compile_options(${TEST_LONGITUDINAL_CONTROLLER_EXE})
   target_link_libraries(${TEST_LONGITUDINAL_CONTROLLER_EXE} ${LONGITUDINAL_CONTROLLER_LIB})
+
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(${TEST_LONGITUDINAL_CONTROLLER_EXE} PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
 endif()
 
 # ament package generation and installing

--- a/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/mpc_utils.hpp
@@ -24,6 +24,13 @@
 #include "motion_common/motion_common.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#else
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#endif
+
 #include "trajectory_follower/interpolate.hpp"
 #include "trajectory_follower/mpc_trajectory.hpp"
 #include "trajectory_follower/visibility_control.hpp"
@@ -32,7 +39,6 @@
 #include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 #include <cmath>
 #include <string>

--- a/control/trajectory_follower/src/longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/src/longitudinal_controller_utils.cpp
@@ -20,7 +20,11 @@
 
 #include <experimental/optional>  // NOLINT
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#else
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#endif
 
 #include <algorithm>
 #include <limits>

--- a/control/trajectory_follower/src/pid.cpp
+++ b/control/trajectory_follower/src/pid.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 

--- a/control/trajectory_follower/test/test_longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/test/test_longitudinal_controller_utils.cpp
@@ -21,7 +21,12 @@
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/quaternion.hpp"
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#else
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#endif
 
 #include <limits>
 

--- a/control/trajectory_follower/test/test_mpc.cpp
+++ b/control/trajectory_follower/test/test_mpc.cpp
@@ -25,7 +25,12 @@
 #include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
 #include "autoware_auto_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#else
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#endif
 
 #include <memory>
 #include <string>

--- a/control/trajectory_follower_nodes/design/longitudinal_controller-design.md
+++ b/control/trajectory_follower_nodes/design/longitudinal_controller-design.md
@@ -148,7 +148,7 @@ AutonomouStuff Lexus RX 450h for under 40 km/h driving.
 
 | Name                                 | Type   | Description                                                                                                                                                                             | Default value |
 | :----------------------------------- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| control_rate                         | double | control rate [Hz]                                                                                                                                                                       | 30            |
+| longitudinal_ctrl_period             | double | longitudinal control period [s]                                                                                                                                                         | 0.03          |
 | delay_compensation_time              | double | delay for longitudinal control [s]                                                                                                                                                      | 0.17          |
 | enable_smooth_stop                   | bool   | flag to enable transition to STOPPING                                                                                                                                                   | true          |
 | enable_overshoot_emergency           | bool   | flag to enable transition to EMERGENCY when the ego is over the stop line with a certain distance. See `emergency_state_overshoot_stop_dist`.                                           | true          |
@@ -240,3 +240,4 @@ If the ego is still running, strong acceleration (`strong_stop_acc`) to stop rig
 ## Related issues
 
 - <https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/issues/1058>
+- <https://github.com/autowarefoundation/autoware.universe/issues/701>

--- a/control/trajectory_follower_nodes/include/trajectory_follower_nodes/longitudinal_controller_node.hpp
+++ b/control/trajectory_follower_nodes/include/trajectory_follower_nodes/longitudinal_controller_node.hpp
@@ -115,8 +115,8 @@ private:
   enum class ControlState { DRIVE = 0, STOPPING, STOPPED, EMERGENCY };
   ControlState m_control_state{ControlState::STOPPED};
 
-  // timer callback
-  float64_t m_control_rate;
+  // control period
+  float64_t m_longitudinal_ctrl_period;
 
   // delay compensation
   float64_t m_delay_compensation_time;

--- a/control/trajectory_follower_nodes/param/longitudinal_controller_defaults.param.yaml
+++ b/control/trajectory_follower_nodes/param/longitudinal_controller_defaults.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    control_rate: 30.0
+    longitudinal_ctrl_period: 0.03  # control period [s]
     delay_compensation_time: 0.17
 
     enable_smooth_stop: true

--- a/launch/tier4_control_launch/config/trajectory_follower/longitudinal_controller.param.yaml
+++ b/launch/tier4_control_launch/config/trajectory_follower/longitudinal_controller.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    control_rate: 30.0
+    longitudinal_ctrl_period: 0.03  # control period [s]
     delay_compensation_time: 0.17
 
     enable_smooth_stop: true

--- a/launch/tier4_control_launch/launch/control.launch.py
+++ b/launch/tier4_control_launch/launch/control.launch.py
@@ -112,9 +112,7 @@ def launch_setup(context, *args, **kwargs):
             lon_controller_param,
             vehicle_info_param,
             {
-                "control_rate": LaunchConfiguration("control_rate"),
                 "show_debug_info": LaunchConfiguration("show_debug_info"),
-                "enable_smooth_stop": LaunchConfiguration("enable_smooth_stop"),
                 "enable_pub_debug": LaunchConfiguration("enable_pub_debug"),
             },
         ],
@@ -354,11 +352,7 @@ def generate_launch_description():
     )
 
     # velocity controller
-    add_launch_arg("control_rate", "30.0", "control rate")
     add_launch_arg("show_debug_info", "false", "show debug information")
-    add_launch_arg(
-        "enable_smooth_stop", "true", "enable smooth stop (in velocity controller state)"
-    )
     add_launch_arg("enable_pub_debug", "true", "enable to publish debug information")
 
     # vehicle cmd gate

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
@@ -3,7 +3,6 @@
     occlusion_spot:
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
-      filter_occupancy_grid: true           # [-] whether to filter occupancy grid by morphologyEx or not
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
@@ -5,6 +5,7 @@
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
       filter_occupancy_grid: true           # [-] whether to filter occupancy grid by morphologyEx or not
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
+      use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data
       pedestrian_vel: 1.5                   # [m/s] assume pedestrian is dashing from occlusion at this velocity
       pedestrian_radius: 0.3                # [m] assume pedestrian width(0.2m) + margin(0.1m)
@@ -30,5 +31,5 @@
         min_longitudinal_offset: 1.0     # [m] detection area safety buffer from front bumper.
         max_lateral_distance: 6.0        # [m] buffer around the ego path used to build the detection area.
       grid:
-        free_space_max: 40  # [-] maximum value of a free space cell in the occupancy grid
-        occupied_min: 60    # [-] minimum value of an occupied cell in the occupancy grid
+        free_space_max: 43  # [-] maximum value of a free space cell in the occupancy grid
+        occupied_min: 58    # [-] minimum value of an occupied cell in the occupancy grid

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -123,6 +123,8 @@
           eps_rel: 1.0e-10 # eps rel when solving OSQP
 
       mpt:
+        bounds_search_widths: [0.45, 0.15, 0.05, 0.01]
+
         clearance:  # clearance(distance) between vehicle and roads/objects when generating trajectory
           hard_clearance_from_road: 0.0 # clearance from road boundary[m]
           soft_clearance_from_road: 0.1 # clearance from road boundary[m]

--- a/localization/ndt/CMakeLists.txt
+++ b/localization/ndt/CMakeLists.txt
@@ -46,6 +46,11 @@ target_include_directories(ndt
     $<INSTALL_INTERFACE:include>
 )
 
+target_include_directories(ndt
+  SYSTEM PUBLIC
+    ${PCL_INCLUDE_DIRS}
+)
+
 ament_target_dependencies(ndt PUBLIC ndt_omp ndt_pcl_modified)
 # Can't use ament_target_dependencies() here because it doesn't link PCL
 # properly, see ndt_omp for more information.

--- a/localization/ndt/include/ndt/base.hpp
+++ b/localization/ndt/include/ndt/base.hpp
@@ -15,7 +15,7 @@
 #ifndef NDT__BASE_HPP_
 #define NDT__BASE_HPP_
 
-#include <pcl/io/io.h>
+#include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl/search/kdtree.h>
@@ -30,8 +30,8 @@ public:
   virtual ~NormalDistributionsTransformBase() = default;
 
   virtual void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) = 0;
-  virtual void setInputTarget(const boost::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) = 0;
-  virtual void setInputSource(const boost::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) = 0;
+  virtual void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) = 0;
+  virtual void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) = 0;
 
   virtual void setMaximumIterations(int max_iter) = 0;
   virtual void setResolution(float res) = 0;
@@ -46,15 +46,15 @@ public:
   virtual double getTransformationProbability() const = 0;
   virtual double getNearestVoxelTransformationLikelihood() const = 0;
   virtual double getFitnessScore() = 0;
-  virtual boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const = 0;
-  virtual boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const = 0;
+  virtual pcl::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const = 0;
+  virtual pcl::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const = 0;
   virtual Eigen::Matrix4f getFinalTransformation() const = 0;
   virtual std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
   getFinalTransformationArray() const = 0;
 
   virtual Eigen::Matrix<double, 6, 6> getHessian() const = 0;
 
-  virtual boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const = 0;
+  virtual pcl::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const = 0;
 
   virtual double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const = 0;

--- a/localization/ndt/include/ndt/impl/omp.hpp
+++ b/localization/ndt/include/ndt/impl/omp.hpp
@@ -34,14 +34,14 @@ void NormalDistributionsTransformOMP<PointSource, PointTarget>::align(
 
 template <class PointSource, class PointTarget>
 void NormalDistributionsTransformOMP<PointSource, PointTarget>::setInputTarget(
-  const boost::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr)
+  const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr)
 {
   ndt_ptr_->setInputTarget(map_ptr);
 }
 
 template <class PointSource, class PointTarget>
 void NormalDistributionsTransformOMP<PointSource, PointTarget>::setInputSource(
-  const boost::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr)
+  const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr)
 {
   ndt_ptr_->setInputSource(scan_ptr);
 }
@@ -122,14 +122,14 @@ double NormalDistributionsTransformOMP<PointSource, PointTarget>::getFitnessScor
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<const pcl::PointCloud<PointTarget>>
+pcl::shared_ptr<const pcl::PointCloud<PointTarget>>
 NormalDistributionsTransformOMP<PointSource, PointTarget>::getInputTarget() const
 {
   return ndt_ptr_->getInputTarget();
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<const pcl::PointCloud<PointSource>>
+pcl::shared_ptr<const pcl::PointCloud<PointSource>>
 NormalDistributionsTransformOMP<PointSource, PointTarget>::getInputSource() const
 {
   return ndt_ptr_->getInputSource();
@@ -158,7 +158,7 @@ Eigen::Matrix<double, 6, 6> NormalDistributionsTransformOMP<PointSource, PointTa
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<pcl::search::KdTree<PointTarget>>
+pcl::shared_ptr<pcl::search::KdTree<PointTarget>>
 NormalDistributionsTransformOMP<PointSource, PointTarget>::getSearchMethodTarget() const
 {
   return ndt_ptr_->getSearchMethodTarget();

--- a/localization/ndt/include/ndt/impl/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_generic.hpp
@@ -35,14 +35,14 @@ void NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::align(
 
 template <class PointSource, class PointTarget>
 void NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::setInputTarget(
-  const boost::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr)
+  const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr)
 {
   ndt_ptr_->setInputTarget(map_ptr);
 }
 
 template <class PointSource, class PointTarget>
 void NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::setInputSource(
-  const boost::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr)
+  const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr)
 {
   ndt_ptr_->setInputSource(scan_ptr);
 }
@@ -125,14 +125,14 @@ double NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getFitn
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<const pcl::PointCloud<PointTarget>>
+pcl::shared_ptr<const pcl::PointCloud<PointTarget>>
 NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getInputTarget() const
 {
   return ndt_ptr_->getInputTarget();
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<const pcl::PointCloud<PointSource>>
+pcl::shared_ptr<const pcl::PointCloud<PointSource>>
 NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getInputSource() const
 {
   return ndt_ptr_->getInputSource();
@@ -162,7 +162,7 @@ NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getHessian() c
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<pcl::search::KdTree<PointTarget>>
+pcl::shared_ptr<pcl::search::KdTree<PointTarget>>
 NormalDistributionsTransformPCLGeneric<PointSource, PointTarget>::getSearchMethodTarget() const
 {
   return ndt_ptr_->getSearchMethodTarget();

--- a/localization/ndt/include/ndt/impl/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/impl/pcl_modified.hpp
@@ -35,14 +35,14 @@ void NormalDistributionsTransformPCLModified<PointSource, PointTarget>::align(
 
 template <class PointSource, class PointTarget>
 void NormalDistributionsTransformPCLModified<PointSource, PointTarget>::setInputTarget(
-  const boost::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr)
+  const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr)
 {
   ndt_ptr_->setInputTarget(map_ptr);
 }
 
 template <class PointSource, class PointTarget>
 void NormalDistributionsTransformPCLModified<PointSource, PointTarget>::setInputSource(
-  const boost::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr)
+  const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr)
 {
   ndt_ptr_->setInputSource(scan_ptr);
 }
@@ -126,14 +126,14 @@ double NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getFit
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<const pcl::PointCloud<PointTarget>>
+pcl::shared_ptr<const pcl::PointCloud<PointTarget>>
 NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getInputTarget() const
 {
   return ndt_ptr_->getInputTarget();
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<const pcl::PointCloud<PointSource>>
+pcl::shared_ptr<const pcl::PointCloud<PointSource>>
 NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getInputSource() const
 {
   return ndt_ptr_->getInputSource();
@@ -162,7 +162,7 @@ NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getHessian() 
 }
 
 template <class PointSource, class PointTarget>
-boost::shared_ptr<pcl::search::KdTree<PointTarget>>
+pcl::shared_ptr<pcl::search::KdTree<PointTarget>>
 NormalDistributionsTransformPCLModified<PointSource, PointTarget>::getSearchMethodTarget() const
 {
   return ndt_ptr_->getSearchMethodTarget();

--- a/localization/ndt/include/ndt/omp.hpp
+++ b/localization/ndt/include/ndt/omp.hpp
@@ -17,7 +17,7 @@
 
 #include "ndt/base.hpp"
 
-#include <pcl/io/io.h>
+#include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pclomp/ndt_omp.h>
@@ -33,8 +33,8 @@ public:
   ~NormalDistributionsTransformOMP() = default;
 
   void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) override;
-  void setInputTarget(const boost::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
-  void setInputSource(const boost::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
+  void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
+  void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
 
   void setMaximumIterations(int max_iter) override;
   void setResolution(float res) override;
@@ -49,15 +49,15 @@ public:
   double getTransformationProbability() const override;
   double getNearestVoxelTransformationLikelihood() const override;
   double getFitnessScore() override;
-  boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
-  boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
+  pcl::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
+  pcl::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
   Eigen::Matrix4f getFinalTransformation() const override;
   std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
   getFinalTransformationArray() const override;
 
   Eigen::Matrix<double, 6, 6> getHessian() const override;
 
-  boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
+  pcl::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
   double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
@@ -72,7 +72,7 @@ public:
   pclomp::NeighborSearchMethod getNeighborhoodSearchMethod() const;
 
 private:
-  boost::shared_ptr<pclomp::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
+  pcl::shared_ptr<pclomp::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
 };
 
 #include "ndt/impl/omp.hpp"

--- a/localization/ndt/include/ndt/pcl_generic.hpp
+++ b/localization/ndt/include/ndt/pcl_generic.hpp
@@ -17,7 +17,7 @@
 
 #include "ndt/base.hpp"
 
-#include <pcl/io/io.h>
+#include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl/registration/ndt.h>
@@ -33,8 +33,8 @@ public:
   ~NormalDistributionsTransformPCLGeneric() = default;
 
   void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) override;
-  void setInputTarget(const boost::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
-  void setInputSource(const boost::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
+  void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
+  void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
 
   void setMaximumIterations(int max_iter) override;
   void setResolution(float res) override;
@@ -49,15 +49,15 @@ public:
   double getTransformationProbability() const override;
   double getNearestVoxelTransformationLikelihood() const override;
   double getFitnessScore() override;
-  boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
-  boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
+  pcl::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
+  pcl::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
   Eigen::Matrix4f getFinalTransformation() const override;
   std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
   getFinalTransformationArray() const override;
 
   Eigen::Matrix<double, 6, 6> getHessian() const override;
 
-  boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
+  pcl::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
   double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
@@ -65,7 +65,7 @@ public:
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
 private:
-  boost::shared_ptr<pcl::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
+  pcl::shared_ptr<pcl::NormalDistributionsTransform<PointSource, PointTarget>> ndt_ptr_;
 };
 
 #include "ndt/impl/pcl_generic.hpp"

--- a/localization/ndt/include/ndt/pcl_modified.hpp
+++ b/localization/ndt/include/ndt/pcl_modified.hpp
@@ -19,7 +19,7 @@
 
 #include <ndt_pcl_modified/ndt.hpp>
 
-#include <pcl/io/io.h>
+#include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 
@@ -34,8 +34,8 @@ public:
   ~NormalDistributionsTransformPCLModified() = default;
 
   void align(pcl::PointCloud<PointSource> & output, const Eigen::Matrix4f & guess) override;
-  void setInputTarget(const boost::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
-  void setInputSource(const boost::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
+  void setInputTarget(const pcl::shared_ptr<pcl::PointCloud<PointTarget>> & map_ptr) override;
+  void setInputSource(const pcl::shared_ptr<pcl::PointCloud<PointSource>> & scan_ptr) override;
 
   void setMaximumIterations(int max_iter) override;
   void setResolution(float res) override;
@@ -50,15 +50,15 @@ public:
   double getTransformationProbability() const override;
   double getNearestVoxelTransformationLikelihood() const override;
   double getFitnessScore() override;
-  boost::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
-  boost::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
+  pcl::shared_ptr<const pcl::PointCloud<PointTarget>> getInputTarget() const override;
+  pcl::shared_ptr<const pcl::PointCloud<PointSource>> getInputSource() const override;
   Eigen::Matrix4f getFinalTransformation() const override;
   std::vector<Eigen::Matrix4f, Eigen::aligned_allocator<Eigen::Matrix4f>>
   getFinalTransformationArray() const override;
 
   Eigen::Matrix<double, 6, 6> getHessian() const override;
 
-  boost::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
+  pcl::shared_ptr<pcl::search::KdTree<PointTarget>> getSearchMethodTarget() const override;
 
   double calculateTransformationProbability(
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
@@ -66,7 +66,7 @@ public:
     const pcl::PointCloud<PointSource> & trans_cloud) const override;
 
 private:
-  boost::shared_ptr<pcl::NormalDistributionsTransformModified<PointSource, PointTarget>> ndt_ptr_;
+  pcl::shared_ptr<pcl::NormalDistributionsTransformModified<PointSource, PointTarget>> ndt_ptr_;
 };
 
 #include "ndt/impl/pcl_modified.hpp"

--- a/localization/ndt_pcl_modified/CMakeLists.txt
+++ b/localization/ndt_pcl_modified/CMakeLists.txt
@@ -41,6 +41,11 @@ target_include_directories(ndt_pcl_modified
     $<INSTALL_INTERFACE:include>
 )
 
+target_include_directories(ndt_pcl_modified
+  SYSTEM PUBLIC
+    ${PCL_INCLUDE_DIRS}
+)
+
 ament_target_dependencies(ndt_pcl_modified PCL)
 ament_export_targets(export_ndt_pcl_modified HAS_LIBRARY_TARGET)
 ament_export_dependencies(PCL)

--- a/localization/ndt_pcl_modified/include/ndt_pcl_modified/impl/ndt.hpp
+++ b/localization/ndt_pcl_modified/include/ndt_pcl_modified/impl/ndt.hpp
@@ -81,8 +81,13 @@ void pcl::NormalDistributionsTransformModified<PointSource, PointTarget>::comput
   }
 
   // Initialize Point Gradient and Hessian
+#if PCL_VERSION >= PCL_VERSION_CALC(1, 12, 1)
+  point_jacobian_.setZero();
+  point_jacobian_.block(0, 0, 3, 3).setIdentity();
+#else
   point_gradient_.setZero();
   point_gradient_.block(0, 0, 3, 3).setIdentity();
+#endif
   point_hessian_.setZero();
 
   Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> eig_transformation;
@@ -366,8 +371,13 @@ double pcl::NormalDistributionsTransformModified<PointSource, PointTarget>::comp
   // Hessian is unnecessary for step length determination but gradients are required
   // so derivative and transform data is stored for the next iteration.
   if (step_iterations) {
+#if PCL_VERSION >= PCL_VERSION_CALC(1, 12, 1)
+    NormalDistributionsTransformModified<PointSource, PointTarget>::computeHessian(
+      hessian, trans_cloud);
+#else
     NormalDistributionsTransformModified<PointSource, PointTarget>::computeHessian(
       hessian, trans_cloud, x_t);
+#endif
   }
 
   return a_t;

--- a/localization/ndt_pcl_modified/include/ndt_pcl_modified/ndt.hpp
+++ b/localization/ndt_pcl_modified/include/ndt_pcl_modified/ndt.hpp
@@ -102,7 +102,11 @@ protected:
   using NormalDistributionsTransform<PointSource, PointTarget>::step_size_;
   using NormalDistributionsTransform<PointSource, PointTarget>::gauss_d1_;
   using NormalDistributionsTransform<PointSource, PointTarget>::gauss_d2_;
+#if PCL_VERSION >= PCL_VERSION_CALC(1, 12, 1)
+  using NormalDistributionsTransform<PointSource, PointTarget>::point_jacobian_;
+#else
   using NormalDistributionsTransform<PointSource, PointTarget>::point_gradient_;
+#endif
   using NormalDistributionsTransform<PointSource, PointTarget>::point_hessian_;
   using NormalDistributionsTransform<PointSource, PointTarget>::trans_probability_;
 

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -36,11 +36,22 @@
 
 #include <fmt/format.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#else
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
+#endif
 
 #include <array>
 #include <deque>

--- a/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
+++ b/localization/ndt_scan_matcher/include/ndt_scan_matcher/util_func.hpp
@@ -20,8 +20,14 @@
 #include <std_msgs/msg/color_rgba.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <cmath>

--- a/localization/ndt_scan_matcher/package.xml
+++ b/localization/ndt_scan_matcher/package.xml
@@ -19,6 +19,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -22,10 +22,13 @@
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/ros/marker_helper.hpp>
 
-#include <boost/shared_ptr.hpp>
-
 #include <pcl_conversions/pcl_conversions.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 #include <algorithm>
 #include <cmath>
@@ -410,7 +413,7 @@ void NDTScanMatcher::callbackMapPoints(
   new_ndt_ptr_->setResolution(resolution);
   new_ndt_ptr_->setMaximumIterations(max_iterations);
 
-  boost::shared_ptr<pcl::PointCloud<PointTarget>> map_points_ptr(new pcl::PointCloud<PointTarget>);
+  pcl::shared_ptr<pcl::PointCloud<PointTarget>> map_points_ptr(new pcl::PointCloud<PointTarget>);
   pcl::fromROSMsg(*map_points_msg_ptr, *map_points_ptr);
   new_ndt_ptr_->setInputTarget(map_points_ptr);
   // create Thread
@@ -442,7 +445,7 @@ void NDTScanMatcher::callbackSensorPoints(
   getTransform(base_frame_, sensor_frame, TF_base_to_sensor_ptr);
   const Eigen::Affine3d base_to_sensor_affine = tf2::transformToEigen(*TF_base_to_sensor_ptr);
   const Eigen::Matrix4f base_to_sensor_matrix = base_to_sensor_affine.matrix().cast<float>();
-  boost::shared_ptr<pcl::PointCloud<PointSource>> sensor_points_baselinkTF_ptr(
+  pcl::shared_ptr<pcl::PointCloud<PointSource>> sensor_points_baselinkTF_ptr(
     new pcl::PointCloud<PointSource>);
   pcl::transformPointCloud(
     *sensor_points_sensorTF_ptr, *sensor_points_baselinkTF_ptr, base_to_sensor_matrix);

--- a/localization/stop_filter/package.xml
+++ b/localization/stop_filter/package.xml
@@ -12,7 +12,9 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>tf2</depend>
   <depend>tier4_debug_msgs</depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/map/map_loader/CMakeLists.txt
+++ b/map/map_loader/CMakeLists.txt
@@ -21,6 +21,11 @@ ament_auto_add_library(pointcloud_map_loader_node SHARED
 )
 target_link_libraries(pointcloud_map_loader_node ${PCL_LIBRARIES})
 
+target_include_directories(pointcloud_map_loader_node
+  SYSTEM PUBLIC
+    ${PCL_INCLUDE_DIRS}
+)
+
 rclcpp_components_register_node(pointcloud_map_loader_node
   PLUGIN "PointCloudMapLoaderNode"
   EXECUTABLE pointcloud_map_loader

--- a/map/map_tf_generator/package.xml
+++ b/map/map_tf_generator/package.xml
@@ -12,7 +12,8 @@
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/compare_elevation_map_filter_node.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/compare_elevation_map_filter_node.hpp
@@ -53,7 +53,7 @@ private:
   void elevationMapCallback(const grid_map_msgs::msg::GridMap::ConstSharedPtr elevation_map);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit CompareElevationMapFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/distance_based_compare_map_filter_nodelet.hpp
@@ -45,7 +45,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit DistanceBasedCompareMapFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_approximate_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_approximate_compare_map_filter_nodelet.hpp
@@ -47,7 +47,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit VoxelBasedApproximateCompareMapFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_based_compare_map_filter_nodelet.hpp
@@ -51,7 +51,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit VoxelBasedCompareMapFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_distance_based_compare_map_filter_nodelet.hpp
@@ -49,7 +49,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit VoxelDistanceBasedCompareMapFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace compare_map_segmentation

--- a/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/distance_based_compare_map_filter_nodelet.cpp
@@ -63,7 +63,7 @@ void DistanceBasedCompareMapFilterComponent::input_target_callback(const PointCl
 {
   pcl::PointCloud<pcl::PointXYZ> map_pcl;
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
-  const auto map_pcl_ptr = boost::make_shared<const pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
+  const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
   boost::mutex::scoped_lock lock(mutex_);
   map_ptr_ = map_pcl_ptr;

--- a/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_approximate_compare_map_filter_nodelet.cpp
@@ -72,7 +72,7 @@ void VoxelBasedApproximateCompareMapFilterComponent::input_target_callback(
 {
   pcl::PointCloud<pcl::PointXYZ> map_pcl;
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
-  const auto map_pcl_ptr = boost::make_shared<const pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
+  const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
   boost::mutex::scoped_lock lock(mutex_);
   set_map_in_voxel_grid_ = true;

--- a/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_based_compare_map_filter_nodelet.cpp
@@ -239,7 +239,7 @@ void VoxelBasedCompareMapFilterComponent::input_target_callback(const PointCloud
 {
   pcl::PointCloud<pcl::PointXYZ> map_pcl;
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
-  const auto map_pcl_ptr = boost::make_shared<const pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
+  const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
   boost::mutex::scoped_lock lock(mutex_);
   set_map_in_voxel_grid_ = true;

--- a/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
+++ b/perception/compare_map_segmentation/src/voxel_distance_based_compare_map_filter_nodelet.cpp
@@ -74,7 +74,7 @@ void VoxelDistanceBasedCompareMapFilterComponent::input_target_callback(
 {
   pcl::PointCloud<pcl::PointXYZ> map_pcl;
   pcl::fromROSMsg<pcl::PointXYZ>(*map, map_pcl);
-  const auto map_pcl_ptr = boost::make_shared<const pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
+  const auto map_pcl_ptr = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>(map_pcl);
 
   boost::mutex::scoped_lock lock(mutex_);
   tf_input_frame_ = map_pcl_ptr->header.frame_id;

--- a/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
+++ b/perception/detected_object_validation/src/obstacle_pointcloud_based_validator.cpp
@@ -21,7 +21,12 @@
 #include <pcl/search/kdtree.h>
 #include <pcl/search/pcl_search.h>
 #include <pcl_conversions/pcl_conversions.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
@@ -165,7 +170,7 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
 
   // Create Kd-tree to search neighbor pointcloud to reduce cost.
   pcl::search::Search<pcl::PointXY>::Ptr kdtree =
-    boost::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
+    pcl::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
   kdtree->setInputCloud(obstacle_pointcloud);
 
   for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {

--- a/perception/detected_object_validation/src/occupancy_grid_based_validator.cpp
+++ b/perception/detected_object_validation/src/occupancy_grid_based_validator.cpp
@@ -18,7 +18,11 @@
 
 #include <boost/optional.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>

--- a/perception/detection_by_tracker/CMakeLists.txt
+++ b/perception/detection_by_tracker/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 
 ### Find PCL Dependencies
-find_package(PCL REQUIRED QUIET COMPONENTS common search filters segmentation)
+find_package(PCL REQUIRED)
 
 ### Find Eigen Dependencies
 find_package(eigen3_cmake_module REQUIRED)

--- a/perception/detection_by_tracker/include/detection_by_tracker/debugger.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/debugger.hpp
@@ -31,7 +31,13 @@
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
+++ b/perception/detection_by_tracker/include/detection_by_tracker/detection_by_tracker_core.hpp
@@ -33,7 +33,13 @@
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -67,7 +67,7 @@ private:
   rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr pub_elevation_map_;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_elevation_map_cloud_;
   void onPointcloudMap(const sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_map);
-  void onMapHash(const tier4_external_api_msgs::msg::MapHash::SharedPtr map_hash);
+  void onMapHash(const tier4_external_api_msgs::msg::MapHash::ConstSharedPtr map_hash);
   void onVectorMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr vector_map);
 
   void publish();

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -120,7 +120,7 @@ void ElevationMapLoaderNode::publish()
 }
 
 void ElevationMapLoaderNode::onMapHash(
-  const tier4_external_api_msgs::msg::MapHash::SharedPtr map_hash)
+  const tier4_external_api_msgs::msg::MapHash::ConstSharedPtr map_hash)
 {
   RCLCPP_INFO(this->get_logger(), "subscribe map_hash");
   const auto elevation_map_hash = map_hash->pcd;

--- a/perception/euclidean_cluster/CMakeLists.txt
+++ b/perception/euclidean_cluster/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_auto REQUIRED)
-find_package(PCL REQUIRED QUIET COMPONENTS common search filters segmentation)
+find_package(PCL REQUIRED)
 ament_auto_find_build_dependencies()
 
 

--- a/perception/ground_segmentation/CMakeLists.txt
+++ b/perception/ground_segmentation/CMakeLists.txt
@@ -32,11 +32,12 @@ ament_auto_find_build_dependencies()
 
 include_directories(
   include
-  ${Boost_INCLUDE_DIRS}
-  ${PCL_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
-  ${OpenCV_INCLUDE_DIRS}
-  ${GRID_MAP_INCLUDE_DIR}
+  SYSTEM
+    ${Boost_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIRS}
+    ${OpenCV_INCLUDE_DIRS}
+    ${GRID_MAP_INCLUDE_DIR}
 )
 
 ament_auto_add_library(ground_segmentation SHARED

--- a/perception/ground_segmentation/include/ground_segmentation/ransac_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/ransac_ground_filter_nodelet.hpp
@@ -25,7 +25,13 @@
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
+
 #include <tf2_ros/transform_listener.h>
 
 #include <chrono>

--- a/perception/ground_segmentation/include/ground_segmentation/ray_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/ray_ground_filter_nodelet.hpp
@@ -51,7 +51,13 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
+
 #include <tf2_ros/transform_listener.h>
 
 #include <chrono>

--- a/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
+++ b/perception/ground_segmentation/include/ground_segmentation/scan_ground_filter_nodelet.hpp
@@ -25,7 +25,13 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
+
 #include <tf2_ros/transform_listener.h>
 
 #include <string>

--- a/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/ransac_ground_filter_nodelet.cpp
@@ -17,7 +17,6 @@
 #include <pcl_ros/transforms.hpp>
 
 #include <pcl/common/centroid.h>
-#include <tf2_eigen/tf2_eigen.h>
 
 #include <limits>
 #include <random>
@@ -187,7 +186,7 @@ void RANSACGroundFilterComponent::extractPointsIndices(
 {
   pcl::ExtractIndices<PointType> extract_ground;
   extract_ground.setInputCloud(in_cloud_ptr);
-  extract_ground.setIndices(boost::make_shared<pcl::PointIndices>(in_indices));
+  extract_ground.setIndices(pcl::make_shared<pcl::PointIndices>(in_indices));
 
   extract_ground.setNegative(false);  // true removes the indices, false leaves only the indices
   extract_ground.filter(*out_only_indices_cloud_ptr);

--- a/perception/ground_segmentation/src/ray_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/ray_ground_filter_nodelet.cpp
@@ -297,7 +297,7 @@ void RayGroundFilterComponent::ExtractPointsIndices(
 {
   pcl::ExtractIndices<PointType_> extract_ground;
   extract_ground.setInputCloud(in_cloud_ptr);
-  extract_ground.setIndices(boost::make_shared<pcl::PointIndices>(in_indices));
+  extract_ground.setIndices(pcl::make_shared<pcl::PointIndices>(in_indices));
 
   extract_ground.setNegative(false);  // true removes the indices, false leaves only the indices
   extract_ground.filter(*out_only_indices_cloud_ptr);

--- a/perception/image_projection_based_fusion/package.xml
+++ b/perception/image_projection_based_fusion/package.xml
@@ -20,6 +20,7 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>
   <depend>tier4_perception_msgs</depend>

--- a/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -137,6 +137,13 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     src/debugger.cpp
   )
 
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(lidar_apollo_instance_segmentation PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
+
   target_link_libraries(lidar_apollo_instance_segmentation
     tensorrt_apollo_cnn_lib
   )

--- a/perception/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/detector.hpp
+++ b/perception/lidar_apollo_instance_segmentation/include/lidar_apollo_instance_segmentation/detector.hpp
@@ -21,7 +21,11 @@
 #include <TrtNet.hpp>
 
 #include <pcl/common/transforms.h>
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 #include <tf2_ros/buffer_interface.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/perception/lidar_apollo_instance_segmentation/package.xml
+++ b/perception/lidar_apollo_instance_segmentation/package.xml
@@ -16,6 +16,7 @@
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/perception/lidar_apollo_instance_segmentation/src/cluster2d.cpp
+++ b/perception/lidar_apollo_instance_segmentation/src/cluster2d.cpp
@@ -50,7 +50,11 @@
 #include <autoware_auto_perception_msgs/msg/object_classification.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 geometry_msgs::msg::Quaternion getQuaternionFromRPY(const double r, const double p, const double y)
 {

--- a/perception/lidar_centerpoint/package.xml
+++ b/perception/lidar_centerpoint/package.xml
@@ -14,6 +14,7 @@
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tier4_autoware_utils</depend>
 

--- a/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -46,7 +46,6 @@
 
 namespace map_based_prediction
 {
-
 struct ObjectData
 {
   std_msgs::msg::Header header;

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -18,7 +18,12 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <chrono>

--- a/perception/map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/map_based_prediction/src/map_based_prediction_node.cpp
@@ -428,7 +428,8 @@ bool MapBasedPredictionNode::checkCloseLaneletCondition(
   // of the lanelets that are below max_dist and max_delta_yaw
   if (
     lanelet.first < dist_threshold_for_searching_lanelet_ &&
-    abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_) {
+    (M_PI - delta_yaw_threshold_for_searching_lanelet_ < abs_norm_delta ||
+     abs_norm_delta < delta_yaw_threshold_for_searching_lanelet_)) {
     return true;
   }
 

--- a/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/multi_object_tracker_core.hpp
@@ -31,7 +31,13 @@
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/bicycle_tracker.cpp
@@ -26,7 +26,12 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>

--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -20,7 +20,12 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include "multi_object_tracker/tracker/model/big_vehicle_tracker.hpp"

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -20,7 +20,12 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include "multi_object_tracker/tracker/model/normal_vehicle_tracker.hpp"

--- a/perception/multi_object_tracker/src/tracker/model/pass_through_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pass_through_tracker.cpp
@@ -20,7 +20,12 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include "multi_object_tracker/tracker/model/pass_through_tracker.hpp"

--- a/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/pedestrian_tracker.cpp
@@ -26,7 +26,12 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>

--- a/perception/multi_object_tracker/src/tracker/model/unknown_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/unknown_tracker.cpp
@@ -16,7 +16,13 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #define EIGEN_MPL2_ONLY
 #include "multi_object_tracker/tracker/model/unknown_tracker.hpp"
 #include "multi_object_tracker/utils/utils.hpp"

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -4,7 +4,7 @@
   <arg name="input/object1" default="object1"/>
   <arg name="output/object" default="merged_object"/>
 
-  <node pkg="object_merger" exec="object_association_merger_node" name="object_association_merger" output="screen">
+  <node pkg="object_merger" exec="object_association_merger_node" name="$(anon object_association_merger)" output="screen">
     <remap from="input/object0" to="$(var input/object0)"/>
     <remap from="input/object1" to="$(var input/object1)"/>
     <remap from="output/object" to="$(var output/object)"/>

--- a/perception/occupancy_grid_map_outlier_filter/include/occupancy_grid_map_outlier_filter/occupancy_grid_map_outlier_filter_nodelet.hpp
+++ b/perception/occupancy_grid_map_outlier_filter/include/occupancy_grid_map_outlier_filter/occupancy_grid_map_outlier_filter_nodelet.hpp
@@ -31,6 +31,7 @@
 #include <message_filters/synchronizer.h>
 #include <pcl/filters/extract_indices.h>
 #include <pcl/filters/radius_outlier_removal.h>
+#include <pcl/search/kdtree.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/message_filter.h>
 #include <tf2_ros/transform_listener.h>

--- a/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_nodelet.cpp
+++ b/perception/occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_nodelet.cpp
@@ -21,7 +21,12 @@
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 #include <algorithm>
 #include <memory>
@@ -103,7 +108,7 @@ RadiusSearch2dfilter::RadiusSearch2dfilter(rclcpp::Node & node)
     node.declare_parameter("radius_search_2d_filter.min_points_and_distance_ratio", 400.0f);
   min_points_ = node.declare_parameter("radius_search_2d_filter.min_points", 4);
   max_points_ = node.declare_parameter("radius_search_2d_filter.max_points", 70);
-  kd_tree_ = boost::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
+  kd_tree_ = pcl::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
 }
 
 void RadiusSearch2dfilter::filter(

--- a/perception/shape_estimation/CMakeLists.txt
+++ b/perception/shape_estimation/CMakeLists.txt
@@ -45,6 +45,11 @@ ament_auto_add_library(shape_estimation_lib SHARED
 
 ament_target_dependencies(shape_estimation_lib ${SHAPE_ESTIMATION_DEPENDENCIES})
 
+target_include_directories(shape_estimation_lib
+  SYSTEM PUBLIC
+    "${PCL_INCLUDE_DIRS}"
+)
+
 # workaround to allow deprecated header to build on both galactic and rolling
 if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
   target_compile_definitions(shape_estimation_lib PUBLIC

--- a/perception/shape_estimation/lib/corrector/utils.cpp
+++ b/perception/shape_estimation/lib/corrector/utils.cpp
@@ -17,8 +17,15 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <vector>

--- a/perception/shape_estimation/lib/model/bounding_box.cpp
+++ b/perception/shape_estimation/lib/model/bounding_box.cpp
@@ -24,7 +24,12 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2/LinearMath/Quaternion.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <cmath>

--- a/perception/shape_estimation/src/node.cpp
+++ b/perception/shape_estimation/src/node.cpp
@@ -22,7 +22,12 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <memory>
 

--- a/perception/traffic_light_map_based_detector/package.xml
+++ b/perception/traffic_light_map_based_detector/package.xml
@@ -16,6 +16,7 @@
   <depend>image_geometry</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -36,6 +36,10 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/scene_module/pull_out/util.cpp
 )
 
+target_include_directories(behavior_path_planner_node SYSTEM PUBLIC
+  ${EIGEN3_INCLUDE_DIR}
+)
+
 target_link_libraries(behavior_path_planner_node
   ${OpenCV_LIBRARIES}
 )

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -39,6 +39,9 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/approval.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_factor.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 #include <tier4_planning_msgs/msg/path_change_module.hpp>
 #include <tier4_planning_msgs/msg/path_change_module_array.hpp>
 #include <tier4_planning_msgs/msg/path_change_module_id.hpp>
@@ -67,6 +70,9 @@ using geometry_msgs::msg::TwistStamped;
 using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
 using route_handler::RouteHandler;
+using tier4_planning_msgs::msg::AvoidanceDebugFactor;
+using tier4_planning_msgs::msg::AvoidanceDebugMsg;
+using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
 using tier4_planning_msgs::msg::PathChangeModule;
 using tier4_planning_msgs::msg::PathChangeModuleArray;
 using tier4_planning_msgs::msg::Scenario;
@@ -163,6 +169,7 @@ private:
   rclcpp::Publisher<OccupancyGrid>::SharedPtr debug_drivable_area_publisher_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_drivable_area_lanelets_publisher_;
   rclcpp::Publisher<Path>::SharedPtr debug_path_publisher_;
+  rclcpp::Publisher<AvoidanceDebugMsgArray>::SharedPtr debug_avoidance_msg_array_publisher_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_marker_publisher_;
   void publishDebugMarker(const std::vector<MarkerArray> & debug_markers);
 };

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_tree_manager.hpp
@@ -55,6 +55,7 @@ public:
   BehaviorModuleOutput run(const std::shared_ptr<PlannerData> & data);
   std::vector<std::shared_ptr<SceneModuleStatus>> getModulesStatus();
   std::vector<MarkerArray> getDebugMarkers();
+  AvoidanceDebugMsgArray getAvoidanceDebugMsgArray();
 
 private:
   BehaviorTreeManagerParam bt_manager_param_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -25,6 +25,9 @@
 #include <autoware_auto_planning_msgs/msg/path.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_factor.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 
 #include <memory>
 #include <string>
@@ -154,7 +157,8 @@ private:
   // debug
   mutable DebugData debug_data_;
   void setDebugData(const PathShifter & shifter, const DebugData & debug);
-
+  mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_object;
+  mutable std::vector<AvoidanceDebugMsg> debug_avoidance_initializer_for_shift_point;
   // =====================================
   // ========= helper functions ==========
   // =====================================

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module_data.hpp
@@ -23,6 +23,9 @@
 #include <autoware_auto_planning_msgs/msg/path.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_factor.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 
 #include <memory>
 #include <string>
@@ -33,6 +36,11 @@ namespace behavior_path_planner
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
+
+using tier4_planning_msgs::msg::AvoidanceDebugFactor;
+using tier4_planning_msgs::msg::AvoidanceDebugMsg;
+using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
+
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
@@ -306,6 +314,7 @@ struct DebugData
 
   // tmp for plot
   PathWithLaneId center_line;
+  AvoidanceDebugMsgArray avoidance_debug_msg_array;
 };
 
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_utils.hpp
@@ -57,6 +57,9 @@ void setStartData(
   AvoidPoint & ap, const double start_length, const geometry_msgs::msg::Pose & start,
   const size_t start_idx, const double start_dist);
 
+std::string getUuidStr(const ObjectData & obj);
+
+std::vector<std::string> getUuidStr(const ObjectDataArray & objs);
 }  // namespace behavior_path_planner
 
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__AVOIDANCE__AVOIDANCE_UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -25,6 +25,9 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_factor.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
+#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 
 #include <boost/optional.hpp>
 
@@ -43,6 +46,7 @@ using autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand;
 using route_handler::LaneChangeDirection;
 using route_handler::PullOutDirection;
 using route_handler::PullOverDirection;
+using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
 using visualization_msgs::msg::MarkerArray;
 using PlanResult = PathWithLaneId::SharedPtr;
 
@@ -190,6 +194,12 @@ public:
 
   MarkerArray getDebugMarker() { return debug_marker_; }
 
+  AvoidanceDebugMsgArray::SharedPtr getAvoidanceDebugMsgArray()
+  {
+    debug_avoidance_msg_array_ptr_->header.stamp = clock_->now();
+    return debug_avoidance_msg_array_ptr_;
+  }
+
 private:
   std::string name_;
   rclcpp::Logger logger_;
@@ -197,6 +207,7 @@ private:
 protected:
   MarkerArray debug_marker_;
   rclcpp::Clock::SharedPtr clock_;
+  mutable AvoidanceDebugMsgArray::SharedPtr debug_avoidance_msg_array_ptr_{};
 
 public:
   ApprovalHandler approval_handler_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -45,7 +45,12 @@
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <limits>
 #include <memory>
@@ -69,6 +74,7 @@ inline geometry_msgs::msg::Pose getPose(
 }
 }  // namespace tier4_autoware_utils
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 namespace tf2
 {
 inline void fromMsg(const geometry_msgs::msg::PoseStamped & msg, tf2::Stamped<tf2::Transform> & out)
@@ -110,6 +116,7 @@ inline void doTransform(
   toMsg(v_out, t_out);
 }
 }  // namespace tf2
+#endif
 
 namespace behavior_path_planner
 {

--- a/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utilities.hpp
@@ -74,7 +74,6 @@ inline geometry_msgs::msg::Pose getPose(
 }
 }  // namespace tier4_autoware_utils
 
-#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 namespace tf2
 {
 inline void fromMsg(const geometry_msgs::msg::PoseStamped & msg, tf2::Stamped<tf2::Transform> & out)
@@ -85,7 +84,7 @@ inline void fromMsg(const geometry_msgs::msg::PoseStamped & msg, tf2::Stamped<tf
   fromMsg(msg.pose, tmp);
   out.setData(tmp);
 }
-
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 // Remove after this commit is released
 // https://github.com/ros2/geometry2/commit/e9da371d81e388a589540357c050e262442f1b4a
 inline geometry_msgs::msg::Point & toMsg(const tf2::Vector3 & in, geometry_msgs::msg::Point & out)
@@ -115,8 +114,8 @@ inline void doTransform(
   tf2::Vector3 v_out = t * v_in;
   toMsg(v_out, t_out);
 }
-}  // namespace tf2
 #endif
+}  // namespace tf2
 
 namespace behavior_path_planner
 {

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -52,7 +52,9 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   perception_subscriber_ = create_subscription<PredictedObjects>(
     "~/input/perception", 1, std::bind(&BehaviorPathPlannerNode::onPerception, this, _1));
   scenario_subscriber_ = create_subscription<Scenario>(
-    "~/input/scenario", 1, [this](const Scenario::SharedPtr msg) { current_scenario_ = msg; });
+    "~/input/scenario", 1, [this](const Scenario::ConstSharedPtr msg) {
+      current_scenario_ = std::make_shared<Scenario>(*msg);
+    });
   external_approval_subscriber_ = create_subscription<ApprovalMsg>(
     "~/input/external_approval", 1,
     std::bind(&BehaviorPathPlannerNode::onExternalApproval, this, _1));

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -77,6 +77,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   hazard_signal_publisher_ = create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
   debug_drivable_area_publisher_ = create_publisher<OccupancyGrid>("~/debug/drivable_area", 1);
   debug_path_publisher_ = create_publisher<Path>("~/debug/path_for_visualize", 1);
+  debug_avoidance_msg_array_publisher_ =
+    create_publisher<AvoidanceDebugMsgArray>("~/debug/avoidance_debug_message_array", 1);
 
   // For remote operation
   plan_ready_publisher_ = create_publisher<PathChangeModule>("~/output/ready", 1);
@@ -532,6 +534,7 @@ void BehaviorPathPlannerNode::run()
 
   // for remote operation
   publishModuleStatus(bt_manager_->getModulesStatus());
+  debug_avoidance_msg_array_publisher_->publish(bt_manager_->getAvoidanceDebugMsgArray());
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 

--- a/planning/behavior_path_planner/src/behavior_tree_manager.cpp
+++ b/planning/behavior_path_planner/src/behavior_tree_manager.cpp
@@ -124,6 +124,22 @@ std::vector<MarkerArray> BehaviorTreeManager::getDebugMarkers()
   return data;
 }
 
+AvoidanceDebugMsgArray BehaviorTreeManager::getAvoidanceDebugMsgArray()
+{
+  const auto avoidance_module = std::find_if(
+    scene_modules_.begin(), scene_modules_.end(),
+    [](const std::shared_ptr<SceneModuleInterface> & module_ptr) {
+      return module_ptr->current_state_ == BT::NodeStatus::SUCCESS;
+    });
+  if (avoidance_module != scene_modules_.end()) {
+    const auto & ptr = avoidance_module->get()->getAvoidanceDebugMsgArray();
+    if (ptr) {
+      return *ptr;
+    }
+  }
+  return AvoidanceDebugMsgArray();
+}
+
 BT::NodeStatus BehaviorTreeManager::checkForceApproval(const std::string & name)
 {
   const auto & approval = current_planner_data_->approval.is_force_approved;

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2449,7 +2449,7 @@ void AvoidanceModule::updateRegisteredObject(const ObjectDataArray & now_objects
   };
 
   // -- check now_objects, add it if it has new object id --
-  for (const auto now_obj : now_objects) {
+  for (const auto & now_obj : now_objects) {
     if (!isAlreadyRegistered(now_obj.object.object_id)) {
       registered_objects_.push_back(now_obj);
     }

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_utils.cpp
@@ -192,4 +192,23 @@ void setStartData(
   ap.start_longitudinal = start_dist;
 }
 
+std::string getUuidStr(const ObjectData & obj)
+{
+  std::stringstream hex_value;
+  for (const auto & uuid : obj.object.object_id.uuid) {
+    hex_value << std::hex << std::setfill('0') << std::setw(2) << +uuid;
+  }
+  return hex_value.str();
+}
+
+std::vector<std::string> getUuidStr(const ObjectDataArray & objs)
+{
+  std::vector<std::string> uuids;
+  uuids.reserve(objs.size());
+  for (const auto & o : objs) {
+    uuids.push_back(getUuidStr(o));
+  }
+  return uuids;
+}
+
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -67,41 +67,45 @@ std::pair<TurnIndicatorsCommand, double> TurnSignalDecider::getIntersectionTurnS
   double accumulated_distance = 0;
 
   auto prev_point = path.points.front();
-  auto prev_lane_id = lanelet::InvalId;
+  auto lane_attribute = std::string("none");
   for (const auto & path_point : path.points) {
-    accumulated_distance +=
+    const double path_point_distance =
       tier4_autoware_utils::calcDistance3d(prev_point.point, path_point.point);
+    accumulated_distance += path_point_distance;
     prev_point = path_point;
     const double distance_from_vehicle_front =
       accumulated_distance - vehicle_pose_frenet.length - base_link2front_;
-    if (distance_from_vehicle_front < 0.0) {
-      continue;
+    if (distance_from_vehicle_front > intersection_search_distance_) {
+      return std::make_pair(turn_signal, distance);
     }
     // TODO(Horibe): Route Handler should be a library.
     for (const auto & lane : route_handler.getLaneletsFromIds(path_point.lane_ids)) {
-      if (lane.id() == prev_lane_id) {
-        continue;
+      // judgement of lighting of turn_signal
+      bool lighting_turn_signal = false;
+      if (lane.attributeOr("turn_direction", std::string("none")) != lane_attribute) {
+        if (
+          distance_from_vehicle_front <
+            lane.attributeOr("turn_signal_distance", intersection_search_distance_) &&
+          path_point_distance > 0.0) {
+          lighting_turn_signal = true;
+        }
+      } else {
+        if (
+          lane.hasAttribute("turn_direction") &&
+          distance_from_vehicle_front < path_point_distance && distance_from_vehicle_front > 0) {
+          lighting_turn_signal = true;
+        }
       }
-      prev_lane_id = lane.id();
+      lane_attribute = lane.attributeOr("turn_direction", std::string("none"));
 
-      if (
-        lane.attributeOr("turn_signal_distance", std::numeric_limits<double>::max()) <
-        distance_from_vehicle_front) {
-        continue;
-      }
-      if (lane.attributeOr("turn_direction", std::string("none")) == "left") {
-        turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+      if (lighting_turn_signal) {
+        if (lane_attribute == std::string("left")) {
+          turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+        } else if (lane_attribute == std::string("right")) {
+          turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+        }
         distance = distance_from_vehicle_front;
-        return std::make_pair(turn_signal, distance);
       }
-      if (lane.attributeOr("turn_direction", std::string("none")) == "right") {
-        turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
-        distance = distance_from_vehicle_front;
-        return std::make_pair(turn_signal, distance);
-      }
-    }
-    if (distance_from_vehicle_front > intersection_search_distance_) {
-      return std::make_pair(turn_signal, distance);
     }
   }
   return std::make_pair(turn_signal, distance);

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1136,10 +1136,22 @@ OccupancyGrid generateDrivableArea(
   const double width = max_x - min_x;
   const double height = max_y - min_y;
 
-  lanelet::ConstLanelets drivable_lanes = lanes;
-  if (containsGoal(lanes, route_handler->getGoalLaneId())) {
-    const auto lanes_after_goal = route_handler->getLanesAfterGoal(vehicle_length);
-    drivable_lanes.insert(drivable_lanes.end(), lanes_after_goal.begin(), lanes_after_goal.end());
+  lanelet::ConstLanelets drivable_lanes;
+  {  // add lanes which covers initial and final footprints
+    // 1. add preceding lanes before current pose
+    const auto lanes_before_current_pose =
+      route_handler->getLanesBeforePose(current_pose->pose, vehicle_length);
+    drivable_lanes.insert(
+      drivable_lanes.end(), lanes_before_current_pose.begin(), lanes_before_current_pose.end());
+
+    // 2. add lanes
+    drivable_lanes.insert(drivable_lanes.end(), lanes.begin(), lanes.end());
+
+    // 3. add succeeding lanes after goal
+    if (containsGoal(lanes, route_handler->getGoalLaneId())) {
+      const auto lanes_after_goal = route_handler->getLanesAfterGoal(vehicle_length);
+      drivable_lanes.insert(drivable_lanes.end(), lanes_after_goal.begin(), lanes_after_goal.end());
+    }
   }
 
   OccupancyGrid occupancy_grid;

--- a/planning/behavior_path_planner/src/utilities.cpp
+++ b/planning/behavior_path_planner/src/utilities.cpp
@@ -1711,7 +1711,7 @@ bool checkLaneIsInIntersection(
   const RouteHandler & route_handler, const PathWithLaneId & reference_path,
   const lanelet::ConstLanelets & lanelet_sequence, double & additional_length_to_add)
 {
-  if (lanelet_sequence.empty()) {
+  if (lanelet_sequence.size() < 2) {
     return false;
   }
 

--- a/planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/CMakeLists.txt
@@ -67,11 +67,16 @@ target_include_directories(scene_module_lib
     $<INSTALL_INTERFACE:include>
 )
 
+target_include_directories(scene_module_lib
+  SYSTEM PUBLIC
+    ${PCL_INCLUDE_DIRS}
+)
+
 ament_target_dependencies(scene_module_lib ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
 
 # workaround to allow deprecated header to build on both galactic and rolling
 if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
-  target_compile_definitions(scene_module_lib PUBLIC
+  target_compile_definitions(scene_module_lib PRIVATE
     USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
   )
 endif()
@@ -93,6 +98,13 @@ ament_target_dependencies(scene_module_stop_line ${BEHAVIOR_VELOCITY_PLANNER_DEP
 
 target_link_libraries(scene_module_stop_line scene_module_lib)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_stop_line PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 
 # Scene Module: Crosswalk
 ament_auto_add_library(scene_module_crosswalk SHARED
@@ -113,6 +125,12 @@ ament_target_dependencies(scene_module_crosswalk ${BEHAVIOR_VELOCITY_PLANNER_DEP
 
 target_link_libraries(scene_module_crosswalk scene_module_lib)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_crosswalk PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
 
 # Scene Module: Intersection
 ament_auto_add_library(scene_module_intersection SHARED
@@ -133,6 +151,13 @@ ament_target_dependencies(scene_module_intersection ${BEHAVIOR_VELOCITY_PLANNER_
 
 target_link_libraries(scene_module_intersection scene_module_lib)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_intersection PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 
 # Scene Module: Traffic Light
 ament_auto_add_library(scene_module_traffic_light SHARED
@@ -150,6 +175,13 @@ target_include_directories(scene_module_traffic_light
 ament_target_dependencies(scene_module_traffic_light ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
 
 target_link_libraries(scene_module_traffic_light scene_module_lib)
+
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_traffic_light PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
 
 
 # Scene Module: Blind Spot
@@ -169,6 +201,13 @@ ament_target_dependencies(scene_module_blind_spot ${BEHAVIOR_VELOCITY_PLANNER_DE
 
 target_link_libraries(scene_module_blind_spot scene_module_lib)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_blind_spot PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 
 # Scene Module: Detection Area
 ament_auto_add_library(scene_module_detection_area SHARED
@@ -187,6 +226,13 @@ ament_target_dependencies(scene_module_detection_area ${BEHAVIOR_VELOCITY_PLANNE
 
 target_link_libraries(scene_module_detection_area scene_module_lib)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_detection_area PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 # Scene Module: No Stopping Area
 ament_auto_add_library(scene_module_no_stopping_area SHARED
   src/scene_module/no_stopping_area/manager.cpp
@@ -203,6 +249,13 @@ target_include_directories(scene_module_no_stopping_area
 ament_target_dependencies(scene_module_no_stopping_area ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
 
 target_link_libraries(scene_module_no_stopping_area scene_module_lib)
+
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_no_stopping_area PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
 
 
 # Scene Module: Virtual Traffic Light
@@ -221,6 +274,13 @@ target_include_directories(scene_module_virtual_traffic_light
 ament_target_dependencies(scene_module_virtual_traffic_light ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
 
 target_link_libraries(scene_module_virtual_traffic_light scene_module_lib)
+
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_virtual_traffic_light PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
 
 
 # SceneModule OcclusionSpot
@@ -245,6 +305,13 @@ target_include_directories(occlusion_spot_lib
 
 ament_target_dependencies(occlusion_spot_lib ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(occlusion_spot_lib PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 ament_auto_add_library(scene_module_occlusion_spot SHARED
   src/scene_module/occlusion_spot/manager.cpp
   src/scene_module/occlusion_spot/debug.cpp
@@ -261,6 +328,13 @@ ament_target_dependencies(scene_module_occlusion_spot ${BEHAVIOR_VELOCITY_PLANNE
 
 target_link_libraries(scene_module_occlusion_spot scene_module_lib occlusion_spot_lib)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_occlusion_spot PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 # Scene Module Manager
 ament_auto_add_library(scene_module_manager SHARED
   src/planner_manager.cpp
@@ -276,6 +350,12 @@ ament_target_dependencies(scene_module_manager ${BEHAVIOR_VELOCITY_PLANNER_DEPEN
 
 target_link_libraries(scene_module_manager scene_module_lib)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(scene_module_manager PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
 
 # Node
 ament_auto_add_library(behavior_velocity_planner SHARED
@@ -306,6 +386,13 @@ target_link_libraries(behavior_velocity_planner
 
 ament_export_dependencies(${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(behavior_velocity_planner PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 rclcpp_components_register_node(behavior_velocity_planner
   PLUGIN "behavior_velocity_planner::BehaviorVelocityPlannerNode"
   EXECUTABLE behavior_velocity_planner_node
@@ -320,6 +407,13 @@ if(BUILD_TESTING)
   ament_auto_add_library(utilization SHARED
     src/utilization/util.cpp
   )
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(utilization PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
+
   # Gtest for utilization
   ament_add_gtest(utilization-test
     test/src/test_state_machine.cpp
@@ -330,6 +424,12 @@ if(BUILD_TESTING)
     gtest_main
     utilization
   )
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(utilization-test PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
 
   # Gtest for occlusion spot
   ament_add_gtest(occlusion_spot-test
@@ -341,6 +441,12 @@ if(BUILD_TESTING)
     gtest_main
     scene_module_occlusion_spot
   )
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(occlusion_spot-test PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
 
 endif()
 

--- a/planning/behavior_velocity_planner/README.md
+++ b/planning/behavior_velocity_planner/README.md
@@ -52,4 +52,5 @@ So for example, in order to stop at a stop line with the vehicles' front on the 
 | `forward_path_length`   | double | forward path length                                                                 |
 | `backward_path_length`  | double | backward path length                                                                |
 | `max_accel`             | double | (to be a global parameter) max acceleration of the vehicle                          |
+| `system_delay`          | double | (to be a global parameter) delay time until output control command                  |
 | `delay_response_time`   | double | (to be a global parameter) delay time of the vehicle's response to control commands |

--- a/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
+++ b/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
@@ -3,7 +3,6 @@
     occlusion_spot:
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
-      filter_occupancy_grid: true           # [-] whether to filter occupancy grid by morphologyEx or not
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data

--- a/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
+++ b/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
@@ -31,5 +31,5 @@
         min_longitudinal_offset: 1.0     # [m] detection area safety buffer from front bumper.
         max_lateral_distance: 6.0        # [m] buffer around the ego path used to build the detection area.
       grid:
-        free_space_max: 40  # [-] maximum value of a free space cell in the occupancy grid
-        occupied_min: 60    # [-] minimum value of an occupied cell in the occupancy grid
+        free_space_max: 43  # [-] maximum value of a free space cell in the occupancy grid
+        occupied_min: 58    # [-] minimum value of an occupied cell in the occupancy grid

--- a/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
+++ b/planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.hpp
@@ -62,6 +62,7 @@ struct PlannerData
     max_stop_acceleration_threshold = node.declare_parameter(
       "max_accel", -5.0);  // TODO(someone): read min_acc in velocity_controller.param.yaml?
     max_stop_jerk_threshold = node.declare_parameter("max_jerk", -5.0);
+    system_delay = node.declare_parameter("system_delay", 0.50);
     delay_response_time = node.declare_parameter("delay_response_time", 0.50);
   }
   // tf
@@ -97,6 +98,7 @@ struct PlannerData
   // additional parameters
   double max_stop_acceleration_threshold;
   double max_stop_jerk_threshold;
+  double system_delay;
   double delay_response_time;
   double stop_line_extend_length;
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -20,7 +20,11 @@
 
 #include <geometry_msgs/msg/point.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <memory>
 #include <string>

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
@@ -109,7 +109,7 @@ namespace occlusion_cost_value
 static constexpr unsigned char FREE_SPACE = 0;
 static constexpr unsigned char UNKNOWN = 50;
 static constexpr unsigned char OCCUPIED = 100;
-static constexpr unsigned char UNKNOWN_IMAGE = 128;
+static constexpr unsigned char UNKNOWN_IMAGE = 100;
 static constexpr unsigned char OCCUPIED_IMAGE = 255;
 }  // namespace occlusion_cost_value
 
@@ -133,24 +133,7 @@ struct GridParam
   int free_space_max;  // maximum value of a freespace cell in the occupancy grid
   int occupied_min;    // minimum value of an occupied cell in the occupancy grid
 };
-struct OcclusionSpotSquare
-{
-  grid_map::Index index;        // index of the anchor
-  grid_map::Position position;  // position of the anchor
-  int min_occlusion_size;       // number of cells for each side of the square
-};
-// @brief structure representing a OcclusionSpot on the OccupancyGrid
-struct OcclusionSpot
-{
-  double distance_along_lanelet;
-  lanelet::ConstLanelet lanelet;
-  lanelet::BasicPoint2d position;
-};
-//!< @brief Return true
-// if the given cell is a occlusion_spot square of size min_size*min_size in the given grid
-bool isOcclusionSpotSquare(
-  OcclusionSpotSquare & occlusion_spot, const grid_map::Matrix & grid_data,
-  const grid_map::Index & cell, const int min_occlusion_size, const grid_map::Size & grid_size);
+
 //!< @brief Find all occlusion spots inside the given lanelet
 void findOcclusionSpots(
   std::vector<grid_map::Position> & occlusion_spot_positions, const grid_map::GridMap & grid,
@@ -159,10 +142,6 @@ void findOcclusionSpots(
 bool isCollisionFree(
   const grid_map::GridMap & grid, const grid_map::Position & p1, const grid_map::Position & p2,
   const double radius);
-//!< @brief get the corner positions of the square described by the given anchor
-void getCornerPositions(
-  std::vector<grid_map::Position> & corner_positions, const grid_map::GridMap & grid,
-  const OcclusionSpotSquare & occlusion_spot_square);
 boost::optional<Polygon2d> generateOccupiedPolygon(
   const Polygon2d & occupancy_poly, const Polygons2d & stuck_vehicle_foot_prints,
   const Polygons2d & moving_vehicle_foot_prints, const Point & position);
@@ -180,8 +159,7 @@ void denoiseOccupancyGridCV(
   const OccupancyGrid::ConstSharedPtr occupancy_grid_ptr,
   const Polygons2d & stuck_vehicle_foot_prints, const Polygons2d & moving_vehicle_foot_prints,
   grid_map::GridMap & grid_map, const GridParam & param, const bool is_show_debug_window,
-  const bool filter_occupancy_grid, const bool use_object_footprints,
-  const bool use_object_ray_casts);
+  const int num_iter, const bool use_object_footprints, const bool use_object_ray_casts);
 void addObjectsToGridMap(const std::vector<PredictedObject> & objs, grid_map::GridMap & grid);
 }  // namespace grid_utils
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/grid_utils.hpp
@@ -40,7 +40,12 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <vector>
 
@@ -54,7 +59,7 @@ inline void fromMsg(const geometry_msgs::msg::PoseStamped & msg, tf2::Stamped<tf
   fromMsg(msg.pose, tmp);
   out.setData(tmp);
 }
-
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 // Remove after this commit is released
 // https://github.com/ros2/geometry2/commit/e9da371d81e388a589540357c050e262442f1b4a
 inline geometry_msgs::msg::Point & toMsg(const tf2::Vector3 & in, geometry_msgs::msg::Point & out)
@@ -84,6 +89,7 @@ inline void doTransform(
   tf2::Vector3 v_out = t * v_in;
   toMsg(v_out, t_out);
 }
+#endif
 }  // namespace tf2
 
 namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
@@ -223,7 +223,9 @@ void clipPathByLength(
 //!< @brief extract target vehicles
 bool isStuckVehicle(const PredictedObject & obj, const double min_vel);
 bool isMovingVehicle(const PredictedObject & obj, const double min_vel);
-std::vector<PredictedObject> extractVehicles(const PredictedObjects::ConstSharedPtr objects_ptr);
+std::vector<PredictedObject> extractVehicles(
+  const PredictedObjects::ConstSharedPtr objects_ptr, const Point ego_position,
+  const double distance);
 std::vector<PredictedObject> filterVehiclesByDetectionArea(
   const std::vector<PredictedObject> & objs, const Polygons2d & polys);
 bool isVehicle(const ObjectClassification & obj_class);

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
@@ -34,7 +34,12 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/LaneletMap.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <chrono>

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
@@ -121,7 +121,6 @@ struct PlannerParam
   bool is_show_occlusion;           // [-]
   bool is_show_cv_window;           // [-]
   bool is_show_processing_time;     // [-]
-  bool filter_occupancy_grid;       // [-]
   bool use_object_info;             // [-]
   bool use_moving_object_ray_cast;  // [-]
   bool use_partition_lanelet;       // [-]

--- a/planning/behavior_velocity_planner/include/utilization/arc_lane_util.hpp
+++ b/planning/behavior_velocity_planner/include/utilization/arc_lane_util.hpp
@@ -23,8 +23,14 @@
 
 #include <boost/optional.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <memory>

--- a/planning/behavior_velocity_planner/occlusion-spot-design.md
+++ b/planning/behavior_velocity_planner/occlusion-spot-design.md
@@ -112,7 +112,6 @@ obstacle that can run out from occlusion is interruped by moving vehicle.
 
 | Parameter               | Type | Description                                                      |
 | ----------------------- | ---- | ---------------------------------------------------------------- |
-| `filter_occupancy_grid` | bool | [-] whether to filter occupancy grid by morphologyEx or not.     |
 | `use_object_info`       | bool | [-] whether to reflect object info to occupancy grid map or not. |
 | `use_partition_lanelet` | bool | [-] whether to use partition lanelet map data.                   |
 

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -23,7 +23,12 @@
 
 #include <lanelet2_routing/Route.h>
 #include <pcl/common/transforms.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 #include <functional>
 #include <memory>

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -16,7 +16,11 @@
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <vector>
 

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
@@ -16,7 +16,11 @@
 #include <tier4_autoware_utils/trajectory/trajectory.hpp>
 #include <utilization/util.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 #include <algorithm>
 #include <memory>

--- a/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/debug.cpp
@@ -18,7 +18,11 @@
 
 #include <tier4_autoware_utils/planning/planning_marker_helper.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <string>
 #include <vector>

--- a/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/no_stopping_area/scene_no_stopping_area.cpp
@@ -22,7 +22,12 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <lanelet2_core/utility/Optional.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 #include <algorithm>
 #include <limits>

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/grid_utils.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/grid_utils.cpp
@@ -488,11 +488,10 @@ void denoiseOccupancyGridCV(
     cv::Scalar(grid_utils::occlusion_cost_value::OCCUPIED));
   toQuantizedImage(occupancy_grid, &cv_image, param);
 
-  //! show orignal occupancy grid to compare difference
+  //! show original occupancy grid to compare difference
   if (is_show_debug_window) {
     cv::namedWindow("original", cv::WINDOW_NORMAL);
     cv::imshow("original", cv_image);
-    cv::waitKey(1);
   }
 
   //! raycast object shadow using vehicle
@@ -503,7 +502,6 @@ void denoiseOccupancyGridCV(
     if (is_show_debug_window) {
       cv::namedWindow("object ray shadow", cv::WINDOW_NORMAL);
       cv::imshow("object ray shadow", cv_image);
-      cv::waitKey(1);
     }
   }
 

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
@@ -58,7 +58,6 @@ OcclusionSpotModuleManager::OcclusionSpotModuleManager(rclcpp::Node & node)
         "[behavior_velocity]: occlusion spot pass judge method has invalid argument"};
     }
   }
-  pp.filter_occupancy_grid = node.declare_parameter(ns + ".filter_occupancy_grid", false);
   pp.use_object_info = node.declare_parameter(ns + ".use_object_info", true);
   pp.use_moving_object_ray_cast = node.declare_parameter(ns + ".use_moving_object_ray_cast", true);
   pp.use_partition_lanelet = node.declare_parameter(ns + ".use_partition_lanelet", false);

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
@@ -59,8 +59,8 @@ OcclusionSpotModuleManager::OcclusionSpotModuleManager(rclcpp::Node & node)
     }
   }
   pp.filter_occupancy_grid = node.declare_parameter(ns + ".filter_occupancy_grid", false);
-  pp.use_object_info = node.declare_parameter(ns + ".use_object_info", false);
-  pp.use_moving_object_ray_cast = node.declare_parameter(ns + ".use_moving_object_ray_cast", false);
+  pp.use_object_info = node.declare_parameter(ns + ".use_object_info", true);
+  pp.use_moving_object_ray_cast = node.declare_parameter(ns + ".use_moving_object_ray_cast", true);
   pp.use_partition_lanelet = node.declare_parameter(ns + ".use_partition_lanelet", false);
   pp.pedestrian_vel = node.declare_parameter(ns + ".pedestrian_vel", 1.5);
   pp.pedestrian_radius = node.declare_parameter(ns + ".pedestrian_radius", 0.5);

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
@@ -216,11 +216,17 @@ bool isMovingVehicle(const PredictedObject & obj, const double min_vel)
   return std::abs(obj_vel) > min_vel;
 }
 
-std::vector<PredictedObject> extractVehicles(const PredictedObjects::ConstSharedPtr objects_ptr)
+std::vector<PredictedObject> extractVehicles(
+  const PredictedObjects::ConstSharedPtr objects_ptr, const Point ego_position,
+  const double distance)
 {
   std::vector<PredictedObject> vehicles;
   for (const auto & obj : objects_ptr->objects) {
     if (occlusion_spot_utils::isVehicle(obj)) {
+      const auto & o = obj.kinematics.initial_pose_with_covariance.pose.position;
+      const auto & p = ego_position;
+      // Don't consider far vehicle
+      if (std::hypot(p.x - o.x, p.y - o.y) > distance) continue;
       vehicles.emplace_back(obj);
     }
   }

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/risk_predictive_braking.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/risk_predictive_braking.cpp
@@ -48,6 +48,8 @@ void applySafeVelocityConsideringPossibleCollision(
       (l_obs < 0 && v0 <= v_safe)
         ? v_safe
         : planning_utils::calcDecelerationVelocityFromDistanceToTarget(j_min, a_min, a0, v0, l_obs);
+    // skip non effective velocity insertion
+    if (original_vel < v_safe) continue;
     // compare safe velocity consider EBS, minimum allowed velocity and original velocity
     const double safe_velocity = calculateInsertVelocity(v_slow_down, v_safe, v_min, original_vel);
     possible_collision.obstacle_info.safe_motion.safe_velocity = safe_velocity;

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
@@ -151,9 +151,12 @@ bool OcclusionSpotModule::modifyPathVelocity(
       filtered_vehicles, stuck_vehicle_foot_prints, moving_vehicle_foot_prints,
       param_.stuck_vehicle_vel);
     // occ -> image
+    // find out occlusion from erode occlusion candidate num iter is strength of filter
+    const int num_iter = static_cast<int>(
+      (param_.detection_area.min_occlusion_spot_size / occ_grid_ptr->info.resolution) - 1);
     grid_utils::denoiseOccupancyGridCV(
       occ_grid_ptr, stuck_vehicle_foot_prints, moving_vehicle_foot_prints, grid_map, param_.grid,
-      param_.is_show_cv_window, param_.filter_occupancy_grid, param_.use_object_info,
+      param_.is_show_cv_window, num_iter, param_.use_object_info,
       param_.use_moving_object_ray_cast);
     DEBUG_PRINT(show_time, "grid [ms]: ", stop_watch_.toc("processing_time", true));
     // Note: Don't consider offset from path start to ego here
@@ -183,8 +186,10 @@ bool OcclusionSpotModule::modifyPathVelocity(
   // these debug topics needs computation resource
   debug_data_.z = path->points.front().point.pose.position.z;
   debug_data_.possible_collisions = possible_collisions;
-  debug_data_.path_interpolated = path_interpolated;
-  debug_data_.path_raw = clipped_path;
+  if (param_.is_show_occlusion) {
+    debug_data_.path_interpolated = path_interpolated;
+    debug_data_.path_raw.points = clipped_path.points;
+  }
   DEBUG_PRINT(show_time, "total [ms]: ", stop_watch_.toc("total_processing_time", true));
   return true;
 }

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
@@ -92,8 +92,7 @@ bool OcclusionSpotModule::modifyPathVelocity(
     param_.v.max_stop_accel = planner_data_->max_stop_acceleration_threshold;
     param_.v.v_ego = planner_data_->current_velocity->twist.linear.x;
     param_.v.a_ego = planner_data_->current_accel.get();
-    // introduce delay ratio until system delay param will introduce
-    param_.v.delay_time = 0.5;
+    param_.v.delay_time = planner_data_->system_delay;
     const double detection_area_offset = 5.0;  // for visualization and stability
     param_.detection_area_max_length =
       planning_utils::calcJudgeLineDistWithJerkLimit(
@@ -137,7 +136,8 @@ bool OcclusionSpotModule::modifyPathVelocity(
   }
   DEBUG_PRINT(show_time, "extract[ms]: ", stop_watch_.toc("processing_time", true));
   const auto objects_ptr = planner_data_->predicted_objects;
-  const auto vehicles = utils::extractVehicles(objects_ptr);
+  const auto vehicles =
+    utils::extractVehicles(objects_ptr, ego_pose.position, param_.detection_area_length);
   const std::vector<PredictedObject> filtered_vehicles =
     utils::filterVehiclesByDetectionArea(vehicles, debug_data_.detection_area_polygons);
   DEBUG_PRINT(show_time, "filter obj[ms]: ", stop_watch_.toc("processing_time", true));

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -16,7 +16,11 @@
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 namespace behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
@@ -16,7 +16,11 @@
 #include <utilization/marker_helper.hpp>
 #include <utilization/util.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 namespace behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -19,7 +19,12 @@
 #include <boost/optional.hpp>  // To be replaced by std::optional in C++17
 
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 #include <algorithm>
 #include <map>

--- a/planning/behavior_velocity_planner/src/utilization/path_utilization.cpp
+++ b/planning/behavior_velocity_planner/src/utilization/path_utilization.cpp
@@ -17,7 +17,12 @@
 #include <utilization/path_utilization.hpp>
 
 #include <tf2/LinearMath/Quaternion.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <algorithm>
 #include <memory>

--- a/planning/behavior_velocity_planner/test/src/test_occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_planner/test/src/test_occlusion_spot_utils.cpp
@@ -98,7 +98,7 @@ TEST(calcSlowDownPointsForPossibleCollision, ConsiderSignedOffset)
         std::cout << "v : " << path.points[i].point.longitudinal_velocity_mps << "\t";
       }
       std::cout << std::endl;
-      for (const auto pc : pcs) {
+      for (const auto & pc : pcs) {
         std::cout << "len : " << pc.arc_lane_dist_at_collision.length << "\t";
       }
       std::cout << std::endl;

--- a/planning/behavior_velocity_planner/test/src/utils.hpp
+++ b/planning/behavior_velocity_planner/test/src/utils.hpp
@@ -202,8 +202,6 @@ inline autoware_auto_perception_msgs::msg::PredictedObject generatePredictedObje
   autoware_auto_perception_msgs::msg::PredictedObject obj;
   obj.shape.dimensions.x = 5.0;
   obj.shape.dimensions.y = 2.0;
-  tf2::Quaternion q;
-  obj.kinematics.initial_pose_with_covariance.pose.orientation = tf2::toMsg(q);
   obj.kinematics.initial_twist_with_covariance.twist.linear.x = 0;
   obj.kinematics.initial_pose_with_covariance.pose.position.x = x;
   obj.kinematics.initial_pose_with_covariance.pose.position.y = 0;

--- a/planning/costmap_generator/CMakeLists.txt
+++ b/planning/costmap_generator/CMakeLists.txt
@@ -33,6 +33,13 @@ target_link_libraries(costmap_generator_lib
   FLANN::FLANN
 )
 
+if(${PCL_VERSION} GREATER_EQUAL 1.12.1)
+  find_package(Qhull REQUIRED)
+  target_link_libraries(costmap_generator_lib
+    QHULL::QHULL
+  )
+endif()
+
 ament_auto_add_library(costmap_generator_node SHARED
   nodes/costmap_generator/costmap_generator_node.cpp
 )

--- a/planning/costmap_generator/README.md
+++ b/planning/costmap_generator/README.md
@@ -31,26 +31,27 @@ None
 
 ### Parameters
 
-| Name                         | Type   | Description                                             |
-| ---------------------------- | ------ | ------------------------------------------------------- |
-| `update_rate`                | double | timer's update rate                                     |
-| `use_objects`                | bool   | whether using `~input/objects` or not                   |
-| `use_points`                 | bool   | whether using `~input/points_no_ground` or not          |
-| `use_wayarea`                | bool   | whether using `wayarea` from `~input/vector_map` or not |
-| `costmap_frame`              | string | created costmap's coordinate                            |
-| `vehicle_frame`              | string | vehicle's coordinate                                    |
-| `map_frame`                  | string | map's coordinate                                        |
-| `grid_min_value`             | double | minimum cost for gridmap                                |
-| `grid_max_value`             | double | maximum cost for gridmap                                |
-| `grid_resolution`            | double | resolution for gridmap                                  |
-| `grid_length_x`              | int    | size of gridmap for x direction                         |
-| `grid_length_y`              | int    | size of gridmap for y direction                         |
-| `grid_position_x`            | int    | offset from coordinate in x direction                   |
-| `grid_position_y`            | int    | offset from coordinate in y direction                   |
-| `maximum_lidar_height_thres` | double | maximum height threshold for pointcloud data            |
-| `minimum_lidar_height_thres` | double | minimum height threshold for pointcloud data            |
-| `expand_rectangle_size`      | double | expand object's rectangle with this value               |
-| `size_of_expansion_kernel`   | int    | kernel size for blurring effect on object's costmap     |
+| Name                         | Type   | Description                                                                                    |
+| ---------------------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `update_rate`                | double | timer's update rate                                                                            |
+| `activate_by_scenario`       | bool   | if true, activate by scenario = parking. Otherwise, activate if vehicle is inside parking lot. |
+| `use_objects`                | bool   | whether using `~input/objects` or not                                                          |
+| `use_points`                 | bool   | whether using `~input/points_no_ground` or not                                                 |
+| `use_wayarea`                | bool   | whether using `wayarea` from `~input/vector_map` or not                                        |
+| `costmap_frame`              | string | created costmap's coordinate                                                                   |
+| `vehicle_frame`              | string | vehicle's coordinate                                                                           |
+| `map_frame`                  | string | map's coordinate                                                                               |
+| `grid_min_value`             | double | minimum cost for gridmap                                                                       |
+| `grid_max_value`             | double | maximum cost for gridmap                                                                       |
+| `grid_resolution`            | double | resolution for gridmap                                                                         |
+| `grid_length_x`              | int    | size of gridmap for x direction                                                                |
+| `grid_length_y`              | int    | size of gridmap for y direction                                                                |
+| `grid_position_x`            | int    | offset from coordinate in x direction                                                          |
+| `grid_position_y`            | int    | offset from coordinate in y direction                                                          |
+| `maximum_lidar_height_thres` | double | maximum height threshold for pointcloud data                                                   |
+| `minimum_lidar_height_thres` | double | minimum height threshold for pointcloud data                                                   |
+| `expand_rectangle_size`      | double | expand object's rectangle with this value                                                      |
+| `size_of_expansion_kernel`   | int    | kernel size for blurring effect on object's costmap                                            |
 
 ### Flowchart
 

--- a/planning/costmap_generator/include/costmap_generator/costmap_generator.hpp
+++ b/planning/costmap_generator/include/costmap_generator/costmap_generator.hpp
@@ -87,6 +87,7 @@ private:
   std::string map_frame_;
 
   double update_rate_;
+  bool activate_by_scenario_;
 
   double grid_min_value_;
   double grid_max_value_;
@@ -152,6 +153,8 @@ private:
   void onScenario(const tier4_planning_msgs::msg::Scenario::ConstSharedPtr msg);
 
   void onTimer();
+
+  bool isActive();
 
   /// \brief initialize gridmap parameters based on rosparam
   void initGridmap();

--- a/planning/freespace_planner/include/freespace_planner/freespace_planner_node.hpp
+++ b/planning/freespace_planner/include/freespace_planner/freespace_planner_node.hpp
@@ -42,7 +42,12 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
+++ b/planning/freespace_planning_algorithms/include/freespace_planning_algorithms/abstract_algorithm.hpp
@@ -19,12 +19,16 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <vector>
 
-// TODO(wep21): Remove these apis
-//              after they are implemented in ros2 geometry2.
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 namespace tf2
 {
 inline void fromMsg(const geometry_msgs::msg::Point & in, tf2::Vector3 & out)
@@ -48,6 +52,7 @@ inline void doTransform(
   toMsg(v_out, t_out);
 }
 }  // namespace tf2
+#endif
 
 namespace freespace_planning_algorithms
 {

--- a/planning/freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/freespace_planning_algorithms/src/astar_search.cpp
@@ -17,7 +17,12 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <vector>
 

--- a/planning/obstacle_avoidance_planner/README.md
+++ b/planning/obstacle_avoidance_planner/README.md
@@ -706,6 +706,15 @@ $N_{circle}$ is the number of circles to check collision.
 - max steering wheel degree
   - `mpt.kinematics.max_steer_deg`
 
+### Boundary search
+
+- `advanced.mpt.bounds_search_widths`
+  - In order to efficiently search precise lateral boundaries on each trajectory point, different resolutions of search widths are defined.
+  - By default, [0.45, 0.15, 0.05, 0.01] is used. In this case, the goal is to get the boundaries' length on each trajectory point with 0.01 [m] resolution.
+  - Firstly, lateral boundaries are searhed with a rough resolution (= 0.45 [m]).
+  - Then, within its 0.45 [m] resolution which boundaries are inside, they are searched again with a bit precise resolution (= 0.15 [m]).
+  - Following this rule, finally boundaries with 0.01 [m] will be found.
+
 ### Assumptions
 
 - EB optimized trajectory length should be longer than MPT optimized trajectory length

--- a/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
+++ b/planning/obstacle_avoidance_planner/config/obstacle_avoidance_planner.param.yaml
@@ -123,6 +123,8 @@
           eps_rel: 1.0e-10 # eps rel when solving OSQP
 
       mpt:
+        bounds_search_widths: [0.45, 0.15, 0.05, 0.01]
+
         clearance:  # clearance(distance) between vehicle and roads/objects when generating trajectory
           hard_clearance_from_road: 0.0 # clearance from road boundary[m]
           soft_clearance_from_road: 0.1 # clearance from road boundary[m]

--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/common_structs.hpp
@@ -245,6 +245,8 @@ struct MPTParam
   double optimization_center_offset;
   double max_steer_rad;
 
+  std::vector<double> bounds_search_widths;
+
   bool soft_constraint;
   bool hard_constraint;
   bool l_inf_norm;

--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -408,6 +408,10 @@ ObstacleAvoidancePlanner::ObstacleAvoidancePlanner(const rclcpp::NodeOptions & n
       "mpt.kinematics.optimization_center_offset",
       vehicle_param_.wheelbase * default_wheelbase_ratio);
 
+    // bounds search
+    mpt_param_.bounds_search_widths =
+      declare_parameter<std::vector<double>>("advanced.mpt.bounds_search_widths");
+
     // collision free constraints
     mpt_param_.l_inf_norm =
       declare_parameter<bool>("advanced.mpt.collision_free_constraints.option.l_inf_norm");

--- a/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -665,7 +665,7 @@ double AdaptiveCruiseController::getMedianVel(const std::vector<nav_msgs::msg::O
   }
 
   std::vector<double> raw_vel_que;
-  for (const auto vel : vel_que) {
+  for (const auto & vel : vel_que) {
     raw_vel_que.emplace_back(vel.twist.twist.linear.x);
   }
 

--- a/planning/obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/obstacle_stop_planner/src/debug_marker.cpp
@@ -16,7 +16,11 @@
 
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 #include <memory>
 #include <vector>

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -30,7 +30,12 @@
 
 #include <pcl/filters/voxel_grid.h>
 #include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
 
 namespace motion_planning
 {

--- a/planning/planning_error_monitor/CMakeLists.txt
+++ b/planning/planning_error_monitor/CMakeLists.txt
@@ -58,5 +58,6 @@ endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE
+    config
     launch
 )

--- a/planning/planning_error_monitor/config/planning_error_monitor.param.yaml
+++ b/planning/planning_error_monitor/config/planning_error_monitor.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    # trajectory check
+    error_interval: 100.0 # error interval distance threshold [m]
+    error_curvature: 2.0 # error curvature threshold [rad/m]
+    error_sharp_angle: 0.785398 # error sharp angle threshold [rad]
+    ignore_too_close_points: 0.01 # ignore too close distance threshold [m]

--- a/planning/planning_error_monitor/launch/planning_error_monitor.launch.xml
+++ b/planning/planning_error_monitor/launch/planning_error_monitor.launch.xml
@@ -5,11 +5,11 @@
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/trajectory" if="$(eval &quot;'$(var run_mode)'=='avoidance'&quot;)"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/trajectory" if="$(eval &quot;'$(var run_mode)'=='surround_obstacle'&quot;)"/>
   <let name="input/trajectory" value="/planning/scenario_planning/lane_driving/trajectory" if="$(eval &quot;'$(var run_mode)'=='obstacle_stop'&quot;)"/>
+  <arg name="planning_error_monitor_param_path" default="$(find-pkg-share planning_error_monitor)/config/planning_error_monitor.param.yaml"/>
   <node name="planning_error_monitor" exec="planning_error_monitor" pkg="planning_error_monitor" output="screen">
+    <!-- load config a file -->
+    <param from="$(var planning_error_monitor_param_path)"/>
+    <!-- remap topic name -->
     <remap from="~/input/trajectory" to="$(var input/trajectory)"/>
-    <param name="error_interval" value="100.0"/>
-    <param name="error_curvature" value="2.0"/>
-    <param name="error_sharp_angle" value="0.785398"/>
-    <param name="ignore_too_close_points" value="0.01"/>
   </node>
 </launch>

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -93,6 +93,8 @@ public:
   Pose getPullOverGoalPose() const;
   lanelet::Id getGoalLaneId() const;
   bool getGoalLanelet(lanelet::ConstLanelet * goal_lanelet) const;
+  std::vector<lanelet::ConstLanelet> getLanesBeforePose(
+    const geometry_msgs::msg::Pose & pose, const double vehicle_length) const;
   std::vector<lanelet::ConstLanelet> getLanesAfterGoal(const double vehicle_length) const;
 
   // for lanelet

--- a/sensing/gnss_poser/CMakeLists.txt
+++ b/sensing/gnss_poser/CMakeLists.txt
@@ -40,6 +40,13 @@ target_link_libraries(gnss_poser_node
   Geographic
 )
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(gnss_poser_node PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 rclcpp_components_register_node(gnss_poser_node
   PLUGIN "gnss_poser::GNSSPoser"
   EXECUTABLE gnss_poser

--- a/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
+++ b/sensing/gnss_poser/include/gnss_poser/gnss_poser_core.hpp
@@ -28,7 +28,13 @@
 #include <boost/circular_buffer.hpp>
 
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/sensing/gnss_poser/package.xml
+++ b/sensing/gnss_poser/package.xml
@@ -12,15 +12,14 @@
   <depend>geo_pos_conv</depend>
   <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_debug_msgs</depend>
   <depend>ublox_msgs</depend>
-
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/sensing/pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/pointcloud_preprocessor/CMakeLists.txt
@@ -73,6 +73,13 @@ if(OPENMP_FOUND)
   )
 endif()
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(pointcloud_preprocessor_filter PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 # ========== Concatenate data ==========
 rclcpp_components_register_node(pointcloud_preprocessor_filter
   PLUGIN "pointcloud_preprocessor::PointCloudConcatenateDataSynchronizerComponent"

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/blockage_diag/blockage_diag_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/blockage_diag/blockage_diag_nodelet.hpp
@@ -71,7 +71,7 @@ private:
   std::string lidar_model_;
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit BlockageDiagComponent(const rclcpp::NodeOptions & options);
 };
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_data_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_data_nodelet.hpp
@@ -159,7 +159,8 @@ private:
     sensor_msgs::msg::PointCloud2::SharedPtr & output_ptr);
   void setPeriod(const int64_t new_period);
   void cloud_callback(
-    const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr, const std::string & topic_name);
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_ptr,
+    const std::string & topic_name);
   void twist_callback(const autoware_auto_vehicle_msgs::msg::VelocityReport::ConstSharedPtr input);
   void timer_callback();
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/crop_box_filter/crop_box_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/crop_box_filter/crop_box_filter_nodelet.hpp
@@ -92,7 +92,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit CropBoxFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
@@ -23,7 +23,13 @@
 
 #include <tf2/convert.h>
 #include <tf2/transform_datatypes.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/approximate_downsample_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/approximate_downsample_filter_nodelet.hpp
@@ -77,7 +77,7 @@ private:
   double voxel_size_z_;
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit ApproximateDownsampleFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/random_downsample_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/random_downsample_filter_nodelet.hpp
@@ -75,7 +75,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit RandomDownsampleFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/voxel_grid_downsample_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/downsample_filter/voxel_grid_downsample_filter_nodelet.hpp
@@ -78,7 +78,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit VoxelGridDownsampleFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/filter.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/filter.hpp
@@ -124,6 +124,7 @@ public:
   using ApproximateTimeSyncPolicy =
     message_filters::Synchronizer<sync_policies::ApproximateTime<PointCloud2, PointIndices>>;
 
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit Filter(
     const std::string & filter_name = "pointcloud_preprocessor_filter",
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
@@ -264,9 +265,6 @@ private:
   void input_indices_callback(const PointCloud2ConstPtr cloud, const PointIndicesConstPtr indices);
 
   void setupTF();
-
-public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 }  // namespace pointcloud_preprocessor
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/dual_return_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/dual_return_outlier_filter_nodelet.hpp
@@ -84,7 +84,7 @@ private:
   float max_distance_;
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit DualReturnOutlierFilterComponent(const rclcpp::NodeOptions & options);
 };
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/radius_search_2d_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/radius_search_2d_outlier_filter_nodelet.hpp
@@ -49,7 +49,7 @@ private:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit RadiusSearch2DOutlierFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_nodelet.hpp
@@ -61,6 +61,7 @@ private:
   }
 
 public:
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit RingOutlierFilterComponent(const rclcpp::NodeOptions & options);
 };
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/voxel_grid_outlier_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/outlier_filter/voxel_grid_outlier_filter_nodelet.hpp
@@ -45,7 +45,7 @@ private:
   pcl::VoxelGrid<pcl::PointXYZ> voxel_filter;
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit VoxelGridOutlierFilterComponent(const rclcpp::NodeOptions & option);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/passthrough_filter/passthrough_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/passthrough_filter/passthrough_filter_nodelet.hpp
@@ -72,7 +72,7 @@ protected:
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit PassThroughFilterComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/passthrough_filter/passthrough_filter_uint16_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/passthrough_filter/passthrough_filter_uint16_nodelet.hpp
@@ -40,7 +40,7 @@ private:
   pcl::PassThroughUInt16<pcl::PCLPointCloud2> impl_;
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit PassThroughFilterUInt16Component(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/passthrough_filter/passthrough_uint16.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/passthrough_filter/passthrough_uint16.hpp
@@ -100,8 +100,8 @@ protected:
   typedef typename pcl::traits::fieldList<PointT>::type FieldList;
 
 public:
-  typedef boost::shared_ptr<PassThroughUInt16<PointT>> Ptr;
-  typedef boost::shared_ptr<const PassThroughUInt16<PointT>> ConstPtr;
+  typedef pcl::shared_ptr<PassThroughUInt16<PointT>> Ptr;
+  typedef pcl::shared_ptr<const PassThroughUInt16<PointT>> ConstPtr;
 
   /** \brief Constructor.
    * \param[in] extract_removed_indices Set to true if you want to be able to extract the indices of

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/pointcloud_accumulator/pointcloud_accumulator_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/pointcloud_accumulator/pointcloud_accumulator_nodelet.hpp
@@ -40,7 +40,7 @@ private:
   boost::circular_buffer<PointCloud2ConstPtr> pointcloud_buffer_;
 
 public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
   explicit PointcloudAccumulatorComponent(const rclcpp::NodeOptions & options);
 };
 }  // namespace pointcloud_preprocessor

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/vector_map_filter/lanelet2_map_filter_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/vector_map_filter/lanelet2_map_filter_nodelet.hpp
@@ -25,7 +25,13 @@
 
 #include <pcl/filters/voxel_grid.h>
 #include <pcl_conversions/pcl_conversions.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
 #include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
+
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_data_nodelet.cpp
@@ -135,7 +135,7 @@ PointCloudConcatenateDataSynchronizerComponent::PointCloudConcatenateDataSynchro
       cloud_stdmap_tmp_ = cloud_stdmap_;
 
       // CAN'T use auto type here.
-      std::function<void(const sensor_msgs::msg::PointCloud2::SharedPtr msg)> cb = std::bind(
+      std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)> cb = std::bind(
         &PointCloudConcatenateDataSynchronizerComponent::cloud_callback, this,
         std::placeholders::_1, input_topics_[d]);
 
@@ -351,11 +351,12 @@ void PointCloudConcatenateDataSynchronizerComponent::setPeriod(const int64_t new
 }
 
 void PointCloudConcatenateDataSynchronizerComponent::cloud_callback(
-  const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr, const std::string & topic_name)
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_ptr, const std::string & topic_name)
 {
   std::lock_guard<std::mutex> lock(mutex_);
+  auto input = std::make_shared<sensor_msgs::msg::PointCloud2>(*input_ptr);
   sensor_msgs::msg::PointCloud2::SharedPtr xyzi_input_ptr(new sensor_msgs::msg::PointCloud2());
-  convertToXYZICloud(input_ptr, xyzi_input_ptr);
+  convertToXYZICloud(input, xyzi_input_ptr);
 
   const bool is_already_subscribed_this = (cloud_stdmap_[topic_name] != nullptr);
   const bool is_already_subscribed_tmp = std::any_of(

--- a/sensing/pointcloud_preprocessor/src/outlier_filter/radius_search_2d_outlier_filter_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/outlier_filter/radius_search_2d_outlier_filter_nodelet.cpp
@@ -32,7 +32,7 @@ RadiusSearch2DOutlierFilterComponent::RadiusSearch2DOutlierFilterComponent(
     search_radius_ = static_cast<double>(declare_parameter("search_radius", 0.2));
   }
 
-  kd_tree_ = boost::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
+  kd_tree_ = pcl::make_shared<pcl::search::KdTree<pcl::PointXY>>(false);
 
   using std::placeholders::_1;
   set_param_res_ = this->add_on_set_parameters_callback(

--- a/sensing/probabilistic_occupancy_grid_map/package.xml
+++ b/sensing/probabilistic_occupancy_grid_map/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>

--- a/sensing/tier4_pcl_extensions/include/tier4_pcl_extensions/voxel_grid_nearest_centroid.hpp
+++ b/sensing/tier4_pcl_extensions/include/tier4_pcl_extensions/voxel_grid_nearest_centroid.hpp
@@ -51,7 +51,12 @@
 #ifndef TIER4_PCL_EXTENSIONS__VOXEL_GRID_NEAREST_CENTROID_HPP_
 #define TIER4_PCL_EXTENSIONS__VOXEL_GRID_NEAREST_CENTROID_HPP_
 
+#include <pcl/pcl_config.h>
+
+#if PCL_VERSION < PCL_VERSION_CALC(1, 12, 0)
 #include <pcl/filters/boost.h>
+#endif
+
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_types.h>
@@ -97,8 +102,8 @@ protected:
   typedef typename PointCloud::ConstPtr PointCloudConstPtr;
 
 public:
-  typedef boost::shared_ptr<VoxelGrid<PointT>> Ptr;
-  typedef boost::shared_ptr<const VoxelGrid<PointT>> ConstPtr;
+  typedef pcl::shared_ptr<VoxelGrid<PointT>> Ptr;
+  typedef pcl::shared_ptr<const VoxelGrid<PointT>> ConstPtr;
 
   /** \brief Simple structure to hold a centroid, covariance and the number of points in a leaf.
    * Inverse covariance, eigen vectors and eigen values are precomputed. */

--- a/sensing/tier4_pcl_extensions/include/tier4_pcl_extensions/voxel_grid_nearest_centroid_impl.hpp
+++ b/sensing/tier4_pcl_extensions/include/tier4_pcl_extensions/voxel_grid_nearest_centroid_impl.hpp
@@ -57,7 +57,11 @@
 #include <Eigen/Dense>
 
 #include <pcl/common/common.h>
+#include <pcl/pcl_config.h>
+
+#if PCL_VERSION < PCL_VERSION_CALC(1, 12, 0)
 #include <pcl/filters/boost.h>
+#endif
 
 #include <limits>
 #include <map>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # Modified from https://github.com/ament/ament_lint/blob/ebd524bb9973d5ec1dc48a670ce54f958a5a0243/ament_flake8/ament_flake8/configuration/ament_flake8.ini
 extend-ignore = B902,C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404,I202,CNL100,E203,E501,Q000
-import-order-style = google
+import-order-style = pep8
 max-line-length = 100
 show-source = true
 statistics = true

--- a/simulator/dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/dummy_perception_publisher/CMakeLists.txt
@@ -56,8 +56,14 @@ target_include_directories(dummy_perception_publisher_node
     $<INSTALL_INTERFACE:include>)
 
 # For using message definitions from the same package
-rosidl_target_interfaces(dummy_perception_publisher_node
-  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
+  rosidl_target_interfaces(dummy_perception_publisher_node
+    ${PROJECT_NAME} "rosidl_typesupport_cpp")
+else()
+  rosidl_get_typesupport_target(
+    cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  target_link_libraries(dummy_perception_publisher_node "${cpp_typesupport_target}")
+endif()
 
 # PCL dependencies – `ament_target_dependencies` doesn't respect the
 # components/modules selected above and only links in `common` ,so we need

--- a/simulator/fault_injection/CMakeLists.txt
+++ b/simulator/fault_injection/CMakeLists.txt
@@ -21,6 +21,7 @@ ament_auto_add_library(fault_injection_node_component SHARED
   src/fault_injection_node/fault_injection_node.cpp
 )
 
+# workaround to allow deprecated function to build on both galactic and rolling
 if(${rosidl_generator_cpp_VERSION} VERSION_LESS 2.5.0)
   target_compile_definitions(fault_injection_node_component PRIVATE
     USE_DEPRECATED_TO_YAML

--- a/simulator/fault_injection/CMakeLists.txt
+++ b/simulator/fault_injection/CMakeLists.txt
@@ -21,6 +21,12 @@ ament_auto_add_library(fault_injection_node_component SHARED
   src/fault_injection_node/fault_injection_node.cpp
 )
 
+if(${rosidl_generator_cpp_VERSION} VERSION_LESS 2.5.0)
+  target_compile_definitions(fault_injection_node_component PRIVATE
+    USE_DEPRECATED_TO_YAML
+  )
+endif()
+
 rclcpp_components_register_node(fault_injection_node_component
   PLUGIN "fault_injection::FaultInjectionNode"
   EXECUTABLE fault_injection_node

--- a/simulator/fault_injection/include/fault_injection/diagnostic_storage.hpp
+++ b/simulator/fault_injection/include/fault_injection/diagnostic_storage.hpp
@@ -39,7 +39,7 @@ public:
   {
     DiagnosticStatus status;
     status.name = diag_config.diag_name;
-    status.hardware_id = "";
+    status.hardware_id = "fault_injection";
     status.level = DiagnosticStatus::OK;
     status.message = "OK";
     event_diag_map_[diag_config.sim_name] = status;

--- a/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
+++ b/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
@@ -39,8 +39,6 @@ namespace fault_injection
 {
 #ifdef USE_DEPRECATED_TO_YAML
 using rosidl_generator_traits::to_yaml;
-#else
-using tier4_simulation_msgs::msg::to_yaml;
 #endif
 
 FaultInjectionNode::FaultInjectionNode(rclcpp::NodeOptions node_options)

--- a/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
+++ b/simulator/fault_injection/src/fault_injection_node/fault_injection_node.cpp
@@ -37,6 +37,12 @@ std::vector<std::string> split(const std::string & str, const char delim)
 
 namespace fault_injection
 {
+#ifdef USE_DEPRECATED_TO_YAML
+using rosidl_generator_traits::to_yaml;
+#else
+using tier4_simulation_msgs::msg::to_yaml;
+#endif
+
 FaultInjectionNode::FaultInjectionNode(rclcpp::NodeOptions node_options)
 : Node("fault_injection", node_options.automatically_declare_parameters_from_overrides(true)),
   updater_(this)
@@ -64,8 +70,7 @@ FaultInjectionNode::FaultInjectionNode(rclcpp::NodeOptions node_options)
 
 void FaultInjectionNode::onSimulationEvents(const SimulationEvents::ConstSharedPtr msg)
 {
-  RCLCPP_DEBUG(
-    this->get_logger(), "Received data: %s", rosidl_generator_traits::to_yaml(*msg).c_str());
+  RCLCPP_DEBUG(this->get_logger(), "Received data: %s", to_yaml(*msg).c_str());
   for (const auto & event : msg->fault_injection_events) {
     if (diagnostic_storage_.isEventRegistered(event.name)) {
       diagnostic_storage_.updateLevel(event.name, event.level);

--- a/simulator/simple_planning_simulator/CMakeLists.txt
+++ b/simulator/simple_planning_simulator/CMakeLists.txt
@@ -25,6 +25,12 @@ autoware_set_compile_options(${PROJECT_NAME})
 
 target_compile_options(${PROJECT_NAME} PRIVATE -Wno-old-style-cast) # RCLCPP_ERROR_THROTTLE() has built-in old-style casts.
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
 
 # Node executable
 rclcpp_components_register_node(${PROJECT_NAME}
@@ -46,6 +52,13 @@ if(BUILD_TESTING)
   target_link_libraries(test_simple_planning_simulator
     ${PROJECT_NAME}
   )
+
+  # workaround to allow deprecated header to build on both galactic and rolling
+  if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+    target_compile_definitions(test_simple_planning_simulator PRIVATE
+      USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+    )
+  endif()
 endif()
 
 

--- a/simulator/simple_planning_simulator/package.xml
+++ b/simulator/simple_planning_simulator/package.xml
@@ -19,7 +19,9 @@
   <depend>motion_common</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_api_utils</depend>
   <depend>tier4_autoware_utils</depend>

--- a/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -16,6 +16,12 @@
 #include "simple_planning_simulator/simple_planning_simulator_core.hpp"
 #include "tf2/utils.h"
 
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#else
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#endif
+
 #include <memory>
 
 using autoware_auto_control_msgs::msg::AckermannControlCommand;

--- a/system/ad_service_state_monitor/CMakeLists.txt
+++ b/system/ad_service_state_monitor/CMakeLists.txt
@@ -29,6 +29,13 @@ ament_auto_add_executable(ad_service_state_monitor
   ${AD_SERVICE_STATE_MONITOR_SRC}
 )
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(ad_service_state_monitor PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/system/ad_service_state_monitor/include/ad_service_state_monitor/state_machine.hpp
+++ b/system/ad_service_state_monitor/include/ad_service_state_monitor/state_machine.hpp
@@ -31,8 +31,6 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
-#include <tf2/utils.h>
-
 #include <deque>
 #include <string>
 #include <vector>

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -14,8 +14,6 @@
 
 #include "ad_service_state_monitor/ad_service_state_monitor_node.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-
 #include <deque>
 #include <memory>
 #include <string>

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/diagnostics.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/diagnostics.cpp
@@ -14,8 +14,6 @@
 
 #include "ad_service_state_monitor/ad_service_state_monitor_node.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-
 #include <string>
 #include <vector>
 

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/state_machine.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/state_machine.cpp
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ad_service_state_monitor/state_machine.hpp"
+
 #include <deque>
 #include <vector>
 
-#define FMT_HEADER_ONLY
-#include "ad_service_state_monitor/state_machine.hpp"
-
+#define FMT_HEADER_ONLY  // NOLINT
 #include <fmt/format.h>
+#include <tf2/utils.h>
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
 
 namespace
 {

--- a/system/default_ad_api/CMakeLists.txt
+++ b/system/default_ad_api/CMakeLists.txt
@@ -18,6 +18,13 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/interface_version.cpp
 )
 
+# workaround to allow deprecated function to build on both galactic and rolling
+if(${rosidl_generator_cpp_VERSION} VERSION_LESS 2.5.0)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE
+    USE_DEPRECATED_TO_YAML
+  )
+endif()
+
 rclcpp_components_register_nodes(${PROJECT_NAME} "default_ad_api::InterfaceVersionNode")
 
 if(BUILD_TESTING)

--- a/system/default_ad_api/CMakeLists.txt
+++ b/system/default_ad_api/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.8)
+project(default_ad_api)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/interface_version.cpp
+)
+
+rclcpp_components_register_nodes(${PROJECT_NAME} "default_ad_api::InterfaceVersionNode")
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(launch_testing_ament_cmake)
+  add_launch_test(test/main.test.py)
+endif()
+
+install(
+  PROGRAMS script/web_server.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_auto_package(INSTALL_TO_SHARE launch test)

--- a/system/default_ad_api/include/default_ad_api/nodes/interface_version.hpp
+++ b/system/default_ad_api/include/default_ad_api/nodes/interface_version.hpp
@@ -1,0 +1,42 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DEFAULT_AD_API__NODES__INTERFACE_VERSION_HPP_
+#define DEFAULT_AD_API__NODES__INTERFACE_VERSION_HPP_
+
+#include "default_ad_api/specs/interface/version.hpp"
+
+#include <component_interface_utils/rclcpp.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace default_ad_api
+{
+
+class InterfaceVersionNode : public rclcpp::Node
+{
+public:
+  explicit InterfaceVersionNode(const rclcpp::NodeOptions & options);
+
+private:
+  using InterfaceVersion = autoware_ad_api_msgs::srv::InterfaceVersion;
+
+  component_interface_utils::Service<ad_api::interface::version::T>::SharedPtr srv_;
+  void onInterfaceVersion(
+    const InterfaceVersion::Request::SharedPtr request,
+    const InterfaceVersion::Response::SharedPtr response);
+};
+
+}  // namespace default_ad_api
+
+#endif  // DEFAULT_AD_API__NODES__INTERFACE_VERSION_HPP_

--- a/system/default_ad_api/include/default_ad_api/specs/interface/version.hpp
+++ b/system/default_ad_api/include/default_ad_api/specs/interface/version.hpp
@@ -1,0 +1,31 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DEFAULT_AD_API__SPECS__INTERFACE__VERSION_HPP_
+#define DEFAULT_AD_API__SPECS__INTERFACE__VERSION_HPP_
+
+#include "autoware_ad_api_msgs/srv/interface_version.hpp"
+
+namespace ad_api::interface::version
+{
+
+struct T
+{
+  using Service = autoware_ad_api_msgs::srv::InterfaceVersion;
+  static constexpr char name[] = "/api/interface/version";
+};
+
+}  // namespace ad_api::interface::version
+
+#endif  // DEFAULT_AD_API__SPECS__INTERFACE__VERSION_HPP_

--- a/system/default_ad_api/launch/default_ad_api.launch.py
+++ b/system/default_ad_api/launch/default_ad_api.launch.py
@@ -1,0 +1,47 @@
+# Copyright 2022 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
+from launch_ros.descriptions import ComposableNode
+
+
+def _create_api_node(node_name, class_name, **kwargs):
+    return ComposableNode(
+        namespace="default_ad_api/node",
+        name=node_name,
+        package="default_ad_api",
+        plugin="default_ad_api::" + class_name,
+        **kwargs
+    )
+
+
+def generate_launch_description():
+    components = [
+        _create_api_node("interface_version", "InterfaceVersionNode"),
+    ]
+    container = ComposableNodeContainer(
+        namespace="default_ad_api",
+        name="container",
+        package="rclcpp_components",
+        executable="component_container_mt",
+        composable_node_descriptions=components,
+    )
+    web_server = Node(
+        package="default_ad_api",
+        name="web_server",
+        executable="web_server.py",
+    )
+    return launch.LaunchDescription([container, web_server])

--- a/system/default_ad_api/package.xml
+++ b/system/default_ad_api/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>default_ad_api</name>
+  <version>0.1.0</version>
+  <description>The default_ad_api package</description>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>autoware_ad_api_msgs</depend>
+  <depend>component_interface_utils</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+
+  <exec_depend>python3-flask</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/system/default_ad_api/script/web_server.py
+++ b/system/default_ad_api/script/web_server.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from threading import Thread
+
+from autoware_ad_api_msgs.srv import InterfaceVersion
+import flask
+import rclpy
+from rclpy.node import Node
+
+app = flask.Flask(__name__)
+cli = None
+
+
+@app.route("/interface/version")
+def interface_version():
+    req = InterfaceVersion.Request()
+    res = cli.call(req)
+    return flask.jsonify(convert_dict(res))
+
+
+def create_service(node, service_type, service_name):
+    cli = node.create_client(service_type, service_name)
+    while not cli.wait_for_service(timeout_sec=1.0):
+        node.get_logger().info(f"service not available, waiting again... ({service_name}")
+    return cli
+
+
+def convert_dict(msg):
+    fields = getattr(msg, "get_fields_and_field_types", None)
+    if not fields:
+        return msg
+    return {field: convert_dict(getattr(msg, field)) for field in fields()}
+
+
+def spin_ros_node():
+    global cli
+    rclpy.init(args=sys.argv)
+    node = Node("ad_api_default_web_server")
+    cli = create_service(node, InterfaceVersion, "/api/interface/version")
+    rclpy.spin(node)
+
+
+if __name__ == "__main__":
+    thread = Thread(target=spin_ros_node)
+    thread.start()
+    app.run(host="localhost", port=8888, debug=True)
+    rclpy.shutdown()
+    thread.join()

--- a/system/default_ad_api/src/interface_version.cpp
+++ b/system/default_ad_api/src/interface_version.cpp
@@ -1,0 +1,38 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "default_ad_api/nodes/interface_version.hpp"
+
+namespace default_ad_api
+{
+
+InterfaceVersionNode::InterfaceVersionNode(const rclcpp::NodeOptions & options)
+: Node("interface_version", options)
+{
+  srv_ = component_interface_utils::create_service<ad_api::interface::version::T>(
+    this, &InterfaceVersionNode::onInterfaceVersion);
+}
+
+void InterfaceVersionNode::onInterfaceVersion(
+  const InterfaceVersion::Request::SharedPtr, const InterfaceVersion::Response::SharedPtr response)
+{
+  response->major = 0;
+  response->minor = 1;
+  response->patch = 0;
+}
+
+}  // namespace default_ad_api
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(default_ad_api::InterfaceVersionNode)

--- a/system/default_ad_api/test/main.test.py
+++ b/system/default_ad_api/test/main.test.py
@@ -1,0 +1,49 @@
+# Copyright 2022 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+import launch
+import launch_testing.actions
+import launch_testing.markers
+import launch_testing.tools
+import pytest
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    path = get_package_share_directory("default_ad_api") + "/launch/default_ad_api.launch.py"
+    specification = importlib.util.spec_from_file_location("launch_script", path)
+    launch_script = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(launch_script)
+    return launch.LaunchDescription(
+        [
+            *launch_script.generate_launch_description().describe_sub_entities(),
+            launch_testing.actions.ReadyToTest(),
+        ]
+    )
+
+
+class TestMain(unittest.TestCase):
+    def test_interface_version(self, launch_service, proc_info, proc_output):
+        prefix = get_package_share_directory("default_ad_api")
+        target = prefix + "/test/node/interface_version.py"
+        action = launch.actions.ExecuteProcess(cmd=["python3", target])
+        with launch_testing.tools.launch_process(launch_service, action, proc_info, proc_output):
+            proc_info.assertWaitForStartup(process=action, timeout=1)
+            proc_info.assertWaitForShutdown(process=action, timeout=3)
+        launch_testing.asserts.assertExitCodes(proc_info, process=action)

--- a/system/default_ad_api/test/node/interface_version.py
+++ b/system/default_ad_api/test/node/interface_version.py
@@ -1,0 +1,38 @@
+# Copyright 2022 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from autoware_ad_api_msgs.srv import InterfaceVersion
+import rclpy
+import rclpy.node
+
+rclpy.init()
+node = rclpy.node.Node("test_client")
+
+client = node.create_client(InterfaceVersion, "/api/interface/version")
+if not client.wait_for_service(timeout_sec=3.0):
+    exit(1)
+
+request = InterfaceVersion.Request()
+future = client.call_async(request)
+rclpy.spin_until_future_complete(node, future)
+response = future.result()
+
+if response.major != 0:
+    exit(1)
+if response.minor != 1:
+    exit(1)
+if response.patch != 0:
+    exit(1)
+
+rclpy.shutdown()

--- a/system/dummy_diag_publisher/package.xml
+++ b/system/dummy_diag_publisher/package.xml
@@ -11,6 +11,7 @@
 
   <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>tier4_autoware_utils</depend>
 
   <exec_depend>rqt_reconfigure</exec_depend>

--- a/system/system_monitor/CMakeLists.txt
+++ b/system/system_monitor/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-stringop-truncation)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
+++ b/system/system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
@@ -183,10 +183,10 @@ void GPUMonitor::addProcessUsage(
   uint32_t info_count = MAX_ARRAY_SIZE;
   std::unique_ptr<nvmlProcessInfo_t[]> infos;
   infos = std::make_unique<nvmlProcessInfo_t[]>(MAX_ARRAY_SIZE);
-  ret = nvmlDeviceGetComputeRunningProcesses_v2(device, &info_count, infos.get());
+  ret = nvmlDeviceGetComputeRunningProcesses(device, &info_count, infos.get());
   if (ret != NVML_SUCCESS) {
     RCLCPP_WARN(
-      this->get_logger(), "Failed to nvmlDeviceGetComputeRunningProcesses_v2 NVML: %s",
+      this->get_logger(), "Failed to nvmlDeviceGetComputeRunningProcesses NVML: %s",
       nvmlErrorString(ret));
     return;
   }
@@ -197,10 +197,10 @@ void GPUMonitor::addProcessUsage(
   // Get Graphics Process ID
   info_count = MAX_ARRAY_SIZE;
   infos = std::make_unique<nvmlProcessInfo_t[]>(MAX_ARRAY_SIZE);
-  ret = nvmlDeviceGetGraphicsRunningProcesses_v2(device, &info_count, infos.get());
+  ret = nvmlDeviceGetGraphicsRunningProcesses(device, &info_count, infos.get());
   if (ret != NVML_SUCCESS) {
     RCLCPP_WARN(
-      this->get_logger(), "Failed to nvmlDeviceGetGraphicsRunningProcesses_v2 NVML: %s",
+      this->get_logger(), "Failed to nvmlDeviceGetGraphicsRunningProcesses NVML: %s",
       nvmlErrorString(ret));
     return;
   }

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/CMakeLists.txt
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/CMakeLists.txt
@@ -19,6 +19,13 @@ ament_auto_add_executable(accel_brake_map_calibrator
 )
 ament_target_dependencies(accel_brake_map_calibrator)
 
+# workaround to allow deprecated header to build on both galactic and rolling
+if(${tf2_geometry_msgs_VERSION} VERSION_LESS 0.18.0)
+  target_compile_definitions(accel_brake_map_calibrator PRIVATE
+    USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+  )
+endif()
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/include/accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -22,6 +22,13 @@
 #include "raw_vehicle_cmd_converter/brake_map.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
+
+#ifdef USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#else
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#endif
+
 #include "tier4_autoware_utils/planning/planning_marker_helper.hpp"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
 

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
@@ -16,6 +16,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>
   <depend>tier4_debug_msgs</depend>

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -984,7 +984,7 @@ T AccelBrakeMapCalibrator::getNearestTimeDataFromVec(
   double nearest_time = std::numeric_limits<double>::max();
   const double target_time = rclcpp::Time(base_data->header.stamp).seconds() - back_time;
   T nearest_time_data;
-  for (const auto data : vec) {
+  for (const auto & data : vec) {
     const double data_time = rclcpp::Time(data->header.stamp).seconds();
     const auto delta_time = std::abs(target_time - data_time);
     if (nearest_time > delta_time) {
@@ -1001,7 +1001,7 @@ DataStampedPtr AccelBrakeMapCalibrator::getNearestTimeDataFromVec(
   double nearest_time = std::numeric_limits<double>::max();
   const double target_time = base_data->data_time.seconds() - back_time;
   DataStampedPtr nearest_time_data;
-  for (const auto data : vec) {
+  for (const auto & data : vec) {
     const double data_time = data->data_time.seconds();
     const auto delta_time = std::abs(target_time - data_time);
     if (nearest_time > delta_time) {


### PR DESCRIPTION
OccupnacyGrid is divided to freespace+occupied image & occlusion image(eroded)
this can remove grid map occlusion size search and remove sensing noise
![Screenshot from 2022-04-24 19-46-03](https://user-images.githubusercontent.com/65527974/164972722-f5e1e4ce-6f74-4279-a3f1-1fcc59dfb6c0.png)

![image](https://user-images.githubusercontent.com/65527974/165051190-bade87dc-93ed-4ceb-94fb-d2283bbef3b8.png)
