### PR TITLE
feat: consider another way of inserting safe velocity

### DIFF
--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
@@ -3,6 +3,8 @@
     occlusion_spot:
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
+      insert_stop_point: true               # [-] whether to insert stop point for occlusion spot
+      consider_pass_judge: false            # [-] whether to consider pass judge for occlusion spot
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data
@@ -13,7 +15,7 @@
         is_show_cv_window: false            # [-] whether to show open_cv debug window
         is_show_processing_time: false      # [-] whether to show processing time
       threshold:
-        detection_area_length: 100.0        # [m] the length of path to consider perception range
+        detection_area_length: 70.0         # [m] the length of path to consider perception range
         stuck_vehicle_vel: 1.0              # [m/s] velocity below this value is assumed to stop
         lateral_distance: 1.5               # [m] maximum lateral distance to consider hidden collision
       motion:

--- a/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
+++ b/launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/occlusion_spot.param.yaml
@@ -3,8 +3,8 @@
     occlusion_spot:
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
-      insert_stop_point: true               # [-] whether to insert stop point for occlusion spot
-      consider_pass_judge: false            # [-] whether to consider pass judge for occlusion spot
+      insert_stop_point: false              # [-] whether to insert stop point for occlusion spot
+      consider_pass_judge: true             # [-] whether to consider pass judge for occlusion spot
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data

--- a/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
+++ b/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
@@ -3,6 +3,8 @@
     occlusion_spot:
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
+      insert_stop_point: false              # [-] whether to insert stop point for occlusion spot
+      consider_pass_judge: false            # [-] whether to consider pass judge for occlusion spot
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data

--- a/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
+++ b/planning/behavior_velocity_planner/config/occlusion_spot.param.yaml
@@ -4,7 +4,7 @@
       detection_method: "occupancy_grid"    # [-] candidate is "occupancy_grid" or "predicted_object"
       pass_judge: "smooth_velocity"         # [-] candidate is "smooth_velocity" or "current_velocity"
       insert_stop_point: false              # [-] whether to insert stop point for occlusion spot
-      consider_pass_judge: false            # [-] whether to consider pass judge for occlusion spot
+      consider_pass_judge: true             # [-] whether to consider pass judge for occlusion spot
       use_object_info: true                 # [-] whether to reflect object info to occupancy grid map or not
       use_moving_object_ray_cast: true      # [-] whether to reflect moving object ray_cast to occupancy grid map or not
       use_partition_lanelet: true           # [-] whether to use partition lanelet map data

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
@@ -108,6 +108,8 @@ struct PlannerParam
 {
   DETECTION_METHOD detection_method;
   PASS_JUDGE pass_judge;
+  bool insert_stop_point;           // [-]
+  bool consider_pass_judge;         // [-]
   bool is_show_occlusion;           // [-]
   bool is_show_cv_window;           // [-]
   bool is_show_processing_time;     // [-]

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/risk_predictive_braking.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/risk_predictive_braking.hpp
@@ -42,8 +42,7 @@ int insertSafeVelocityToPath(
 SafeMotion calculateSafeMotion(const Velocity & v, const double ttc);
 
 double calculateInsertVelocity(
-  const double min_allowed_vel, const double safe_vel, const double min_vel,
-  const double original_vel);
+  const double min_allowed_vel, const double safe_vel, const double original_vel);
 
 }  // namespace occlusion_spot_utils
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/manager.cpp
@@ -58,6 +58,8 @@ OcclusionSpotModuleManager::OcclusionSpotModuleManager(rclcpp::Node & node)
         "[behavior_velocity]: occlusion spot pass judge method has invalid argument"};
     }
   }
+  pp.insert_stop_point = node.declare_parameter(ns + ".insert_stop_point", false);
+  pp.consider_pass_judge = node.declare_parameter(ns + ".consider_pass_judge", true);
   pp.use_object_info = node.declare_parameter(ns + ".use_object_info", true);
   pp.use_moving_object_ray_cast = node.declare_parameter(ns + ".use_moving_object_ray_cast", true);
   pp.use_partition_lanelet = node.declare_parameter(ns + ".use_partition_lanelet", false);

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/occlusion_spot_utils.cpp
@@ -326,7 +326,7 @@ PossibleCollisionInfo calculateCollisionPathPointFromOcclusionSpot(
   {
     const double v_min = param.v.min_allowed_velocity;
     if(!param.insert_stop_point){
-      // this module calulates safe motion according to defined acc/jerk 
+      // this module calculates safe motion according to defined acc/jerk 
       sm = calculateSafeMotion(param.v, ttc);
       sm.safe_velocity = std::max(v_min, sm.safe_velocity);
     } else {

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/risk_predictive_braking.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/risk_predictive_braking.cpp
@@ -35,7 +35,6 @@ void applySafeVelocityConsideringPossibleCollision(
   const double a0 = param.v.a_ego;
   const double j_min = param.v.max_slow_down_jerk;
   const double a_min = param.v.max_slow_down_accel;
-  const double v_min = param.v.min_allowed_velocity;
   for (auto & possible_collision : possible_collisions) {
     const double l_obs = possible_collision.arc_lane_dist_at_collision.length;
     const double original_vel = possible_collision.collision_with_margin.longitudinal_velocity_mps;
@@ -51,7 +50,7 @@ void applySafeVelocityConsideringPossibleCollision(
     // skip non effective velocity insertion
     if (original_vel < v_safe) continue;
     // compare safe velocity consider EBS, minimum allowed velocity and original velocity
-    const double safe_velocity = calculateInsertVelocity(v_slow_down, v_safe, v_min, original_vel);
+    const double safe_velocity = calculateInsertVelocity(v_slow_down, v_safe, original_vel);
     possible_collision.obstacle_info.safe_motion.safe_velocity = safe_velocity;
     const auto & pose = possible_collision.collision_with_margin.pose;
     insertSafeVelocityToPath(pose, safe_velocity, param, inout_path);
@@ -112,14 +111,11 @@ SafeMotion calculateSafeMotion(const Velocity & v, const double ttc)
 }
 
 double calculateInsertVelocity(
-  const double min_allowed_vel, const double safe_vel, const double min_vel,
-  const double original_vel)
+  const double min_allowed_vel, const double safe_vel, const double original_vel)
 {
   const double max_vel_noise = 0.05;
   // ensure safe velocity doesn't exceed maximum allowed pbs deceleration
   double cmp_safe_vel = std::max(min_allowed_vel + max_vel_noise, safe_vel);
-  // ensure safe path velocity is also above ego min velocity
-  cmp_safe_vel = std::max(cmp_safe_vel, min_vel);
   // ensure we only lower the original velocity (and do not increase it)
   cmp_safe_vel = std::min(cmp_safe_vel, original_vel);
   return cmp_safe_vel;

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
@@ -66,8 +66,7 @@ OcclusionSpotModule::OcclusionSpotModule(
   if (param_.detection_method == utils::DETECTION_METHOD::OCCUPANCY_GRID) {
     debug_data_.detection_type = "occupancy";
     //! occupancy grid limitation( 100 * 100 )
-    const double max_length = 35.0;  // current available length
-    param_.detection_area_length = std::min(max_length, param_.detection_area_length);
+    param_.detection_area_max_length = 0.5 * param_.detection_area_length;
   } else if (param_.detection_method == utils::DETECTION_METHOD::PREDICTED_OBJECT) {
     debug_data_.detection_type = "object";
   }
@@ -93,7 +92,9 @@ bool OcclusionSpotModule::modifyPathVelocity(
     param_.v.v_ego = planner_data_->current_velocity->twist.linear.x;
     param_.v.a_ego = planner_data_->current_accel.get();
     param_.v.delay_time = planner_data_->system_delay;
-    const double detection_area_offset = 5.0;  // for visualization and stability
+  }
+  if(param_.consider_pass_judge){
+    const double detection_area_offset = 10.0;  // for visualization and stability
     param_.detection_area_max_length =
       planning_utils::calcJudgeLineDistWithJerkLimit(
         param_.v.v_ego, param_.v.a_ego, param_.v.non_effective_accel, param_.v.non_effective_jerk,

--- a/planning/behavior_velocity_planner/test/src/test_risk_predictive_braking.cpp
+++ b/planning/behavior_velocity_planner/test/src/test_risk_predictive_braking.cpp
@@ -65,18 +65,6 @@ TEST(safeMotion, delay_jerk_acceleration)
   }
 }
 
-TEST(calculateInsertVelocity, min_max)
-{
-  using behavior_velocity_planner::occlusion_spot_utils::calculateInsertVelocity;
-  const double inf = std::numeric_limits<double>::max();
-  // upper bound rpb_vel
-  ASSERT_EQ(calculateInsertVelocity(inf, inf, inf, inf), inf);
-  // lower bound org_vel = 0
-  ASSERT_EQ(calculateInsertVelocity(inf, inf, inf, 0), 0.0);
-  // lower bound min = 0
-  ASSERT_EQ(calculateInsertVelocity(inf, inf, 0, inf), inf);
-}
-
 TEST(insertSafeVelocityToPath, replace_original_at_too_close_case)
 {
   /* straight path


### PR DESCRIPTION
## Description

もともと速度計画に影響のない場所への停止点埋め込みはしないように検知エリアで限定していたが、この速度計画に影響のない値は以下を前提としており、うまく実現するのは難しい。そこでpass judgeというフラグを用いて速度計画に影響がある部分のみを検知エリアとするのか、そもそも経路から横距離何メートル以内の死角はすべて見るようにするのかのフラグの追加
- 速度計画の手法に依存すること
- 車速、加速度がなめらかであること

もともとは急ブレーキを踏んで止まれる速度、止まれる距離を埋め込むこととしていたが、こちらは以下の理由により死角の位置にほぼ停止速度を埋め込み死角がなくなるまで減速を解除しないようにするかどうかのフラグを追加
- 速度計画を用いて検知エリアを作成しているため、通過可能かどうかの判定はより正しく行えるようになった
- もし死角から歩行者が飛び出してきても想定したacc/jerkでブレーキを踏めるとは限らないため、現状死角が解除するまで減速を続ける機能があったほうが、より安全に走行できる。

その他
軽いrefactor



 Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
